### PR TITLE
feat: shared clients and CLI dispatcher (foundations)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -34,7 +34,7 @@ State lives in SurrealDB. No separate Redis/Postgres/SQLite for queues, locks, o
 
 **Origin:** VISION.md, 2026-05-03.
 
-### Soft-delete only — never hard-delete
+### Soft-delete only — never hard-delete (nodes)
 
 Every node carries a `deleted_at: option<datetime>` field. Tombstone instead of deleting.
 
@@ -43,6 +43,16 @@ Every node carries a `deleted_at: option<datetime>` field. Tombstone instead of 
 **Scope:** All node tables (org, repo, issue, pull_request, discussion, comment, commit, user, label).
 
 **Origin:** VISION.md, 2026-05-03.
+
+### Nodes are historical; edges are relational truth
+
+Nodes carry `deleted_at` and are never hard-deleted — they preserve history of what existed and was authored. Edges, by contrast, reflect the current relation between two nodes; when upstream removes the relation (a label unstuck, a "Closes #N" edited away, a referenced commit dropped from a PR), the local edge is hard-deleted outright. No `deleted_at` on edges.
+
+**Why:** An edge that no longer exists upstream is not history — it's a stale fact. Filtering by `deleted_at` on every traversal would poison query patterns and grow indexes forever. Edges are cheap to recreate idempotently; the cost of preserving them is higher than the cost of recomputing.
+
+**Scope:** All edge tables (`has`, `authored`, `has_label`, `closes`, `fixes`, `references_ref`, `contains_commit`, `in_category`, and any future relation tables). Does not change node soft-delete semantics — nodes still tombstone forever.
+
+**Origin:** Issue #6, 2026-05-03.
 
 ### Embedding dimension is a hard schema decision
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -189,3 +189,15 @@ Helpers that paginate over remote APIs (GitHub GraphQL connections, SurrealDB li
 **Scope:** All fetch/sync code that talks to external paginated APIs. Does not constrain in-memory transforms after persistence.
 
 **Origin:** Issue #1, 2026-05-03.
+
+### Ingest stages are pure functions; orchestrators glue them
+
+`fetch*` functions are DB-agnostic and yield parsed values via async generators. `persist*` functions are pure infrastructure: they take a DB handle and a parsed value, and emit no side effects beyond the DB. The CLI command (`tool sync`) is the only place these are composed.
+
+Cross-cutting concerns (label upsert, user upsert, bot detection) live in their own module and are owned by a specific issue; other ingest stages depend on the stable call site, not on the implementation, so they can ship before the owner refines.
+
+**Why:** Stage independence (per the principle above) is enforced by signatures — a fetcher that knows about the DB will eventually grow side effects that break idempotency. A persister that fetches will couple stage cadence to network. Cross-cutting concerns inevitably appear in 3+ places; "owner issue + stub call site" lets parallel work proceed without blocking on the cross-cutting design.
+
+**Scope:** All ingest code (issues, pull requests, discussions, comments, labels, users, bots) and the sync orchestrator.
+
+**Origin:** Issue #3, 2026-05-03.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -202,6 +202,16 @@ Helpers that paginate over remote APIs (GitHub GraphQL connections, SurrealDB li
 
 **Origin:** Issue #1, 2026-05-03.
 
+### Item-level failures don't fail the batch
+
+In phases that process many independent items (embed pass, batch extractions, future post-processing), a single item's failure is logged and skipped, not propagated. Infrastructure-level failures (the embedder daemon is down, the database is unreachable) DO propagate and crash the run. The split is detected by the first-success heuristic: errors before any successful item in the run are treated as infrastructure; errors after at least one success are treated as per-item.
+
+**Why:** A malformed body or a transient 500 from Ollama shouldn't block 1000 healthy items from being embedded in the same run. Idempotency means a re-run picks up just the failures — but only if the rest of the run succeeded. Conversely, if the embedder is unreachable, every item fails and we want to know immediately, not after watching N retries succeed-zero-times.
+
+**Scope:** All multi-item processing phases (embed pass, future extraction or post-processing passes). Does not apply to orchestration commands like `tool sync` where each stage is a precondition for the next.
+
+**Origin:** Issue #11, 2026-05-03.
+
 ### Ingest stages are pure functions; orchestrators glue them
 
 `fetch*` functions are DB-agnostic and yield parsed values via async generators. `persist*` functions are pure infrastructure: they take a DB handle and a parsed value, and emit no side effects beyond the DB. The CLI command (`tool sync`) is the only place these are composed.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -44,15 +44,17 @@ Every node carries a `deleted_at: option<datetime>` field. Tombstone instead of 
 
 **Origin:** VISION.md, 2026-05-03.
 
-### Nodes are historical; edges are relational truth
+### Nodes are historical; edges are relational truth — except structural edges
 
-Nodes carry `deleted_at` and are never hard-deleted — they preserve history of what existed and was authored. Edges, by contrast, reflect the current relation between two nodes; when upstream removes the relation (a label unstuck, a "Closes #N" edited away, a referenced commit dropped from a PR), the local edge is hard-deleted outright. No `deleted_at` on edges.
+Nodes carry `deleted_at` and are never hard-deleted — they preserve history of what existed and was authored. Most edges, by contrast, reflect the current relation between two nodes; when upstream removes the relation (a label unstuck, a "Closes #N" edited away, a referenced commit dropped from a PR), the local edge is hard-deleted outright. No `deleted_at` on edges.
 
-**Why:** An edge that no longer exists upstream is not history — it's a stale fact. Filtering by `deleted_at` on every traversal would poison query patterns and grow indexes forever. Edges are cheap to recreate idempotently; the cost of preserving them is higher than the cost of recomputing.
+**Carve-out — structural edges:** Edges that express identity or parentage are an exception. They are created once at first persist and never recomputed or deleted, so traversals to tombstoned nodes still work. Structural edges include: `has` (repo → child), `has_comment` (issue/pr/discussion → comment), `contains_commit` (pr → commit), `authored` (user → anything), `merged_by`-style links. Everything else is relational and follows recompute-on-sync semantics.
 
-**Scope:** All edge tables (`has`, `authored`, `has_label`, `closes`, `fixes`, `references_ref`, `contains_commit`, `in_category`, and any future relation tables). Does not change node soft-delete semantics — nodes still tombstone forever.
+**Why:** A relational edge that no longer exists upstream is not history — it's a stale fact. Filtering by `deleted_at` on every traversal would poison query patterns and grow indexes forever. Structural edges, however, encode "this comment was born on this issue" — that fact doesn't change when the comment is later tombstoned. Without the structural carve-out, traversal from an issue to its deleted comments would silently break.
 
-**Origin:** Issue #6, 2026-05-03.
+**Scope:** All edge tables. Relational: `has_label`, `closes`, `fixes`, `references_ref`, `in_category`, future cross-references. Structural: `has`, `has_comment`, `contains_commit`, `authored`, parent-pointer edges. Does not change node soft-delete semantics — nodes still tombstone forever.
+
+**Origin:** Issue #6, 2026-05-03. Structural carve-out added in #7, 2026-05-03.
 
 ### Embedding dimension is a hard schema decision
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,191 @@
+# ARCHITECTURE
+
+Reusable architectural principles for `github-embedder-surrealdb`.
+
+This file is the **principle store**. Every design session starts by reading it. When a design decision is reusable across future issues, it gets recorded here so the next session is "look it up" rather than "debate from scratch."
+
+For the *what* and *why* of the project, see `VISION.md`. This file is about *how we make decisions*.
+
+---
+
+## Runtime & Distribution
+
+### Single Bun binary, single language
+
+The CLI is a single Bun + TypeScript binary, distributed via `bun build --compile`. No mixed runtimes, no Python sidecars.
+
+**Why:** Cold-start latency is a first-class concern (Claude Code hooks fire frequently). Single-binary install is the lowest-friction shape for users.
+
+**Scope:** All CLI code, sync code, embedder orchestration. Exception: the embedder daemon itself (Ollama) is external — but the CLI never embeds in-process.
+
+**Origin:** VISION.md, 2026-05-03.
+
+---
+
+## Storage
+
+### SurrealDB is the only stateful system
+
+State lives in SurrealDB. No separate Redis/Postgres/SQLite for queues, locks, or caches. Repo registration, content hashes, embeddings, last-sync timestamps — all on SurrealDB nodes.
+
+**Why:** One source of truth, one connection to manage, one schema to evolve. SurrealDB has graph + vectors + records in one engine; bringing a second store would be premature.
+
+**Scope:** All persistent state. Ephemeral per-process state (in-memory caches during a single sync run) is fine.
+
+**Origin:** VISION.md, 2026-05-03.
+
+### Soft-delete only — never hard-delete
+
+Every node carries a `deleted_at: option<datetime>` field. Tombstone instead of deleting.
+
+**Why:** Hard-deletes break historical context, dangling cross-references, and embeddings that point at vanished nodes. The graph is a memory of what happened, including what was removed.
+
+**Scope:** All node tables (org, repo, issue, pull_request, discussion, comment, commit, user, label).
+
+**Origin:** VISION.md, 2026-05-03.
+
+### Embedding dimension is a hard schema decision
+
+The vector column is fixed at **768 dimensions**, matching `nomic-embed-text`. Changing dimension means a schema migration.
+
+**Why:** The HNSW index is dimension-bound. Treating the dim as soft would add per-row branching with zero practical benefit; we'd rather force a deliberate schema change if we ever switch models.
+
+**Scope:** All embeddable tables (issue, pull_request, discussion, comment).
+
+**Origin:** VISION.md, 2026-05-03.
+
+---
+
+## GitHub access
+
+### GraphQL only — no REST mixing
+
+All GitHub API access goes through `@octokit/graphql`. No REST fallbacks.
+
+**Why:** Discussions require GraphQL anyway. A single client path is simpler than two; auth, retry, and rate-limit handling live in one place.
+
+**Scope:** All fetch logic. If a GraphQL endpoint doesn't expose what we need, we adjust the data model rather than dropping to REST.
+
+**Origin:** VISION.md, 2026-05-03.
+
+### Single token at install level (for now)
+
+One `GITHUB_TOKEN` env var, shared across all mirrored repos.
+
+**Why:** Simplest viable model. Per-repo tokens (needed for private repos under different accounts) are explicitly deferred to a future milestone (`future` label, issue #17).
+
+**Scope:** First Full Sync milestone. Revisit when private/multi-account becomes a real requirement.
+
+**Origin:** VISION.md, 2026-05-03.
+
+---
+
+## Embeddings
+
+### Ollama is the default embedder; HTTP-compatible swap allowed
+
+`nomic-embed-text` on a local Ollama daemon. The CLI reaches it over HTTP. Any HTTP-compatible embedder can replace it via config (`OLLAMA_URL`, `OLLAMA_EMBED_MODEL`).
+
+**Why:** Keeping the model warm across hot-path invocations matters. Ollama is the lowest-friction local option; the HTTP boundary keeps us from coupling to it.
+
+**Scope:** All embedding calls. We do not embed in-process and we do not bundle a model.
+
+**Origin:** VISION.md, 2026-05-03.
+
+### Bots are ingested but not embedded
+
+Bot-authored issues/PRs/comments enter the graph (so structure stays complete) but skip the embedding stage. Detection: GitHub's `User.type == "Bot"` plus account name suffix `[bot]`.
+
+**Why:** Bot content is mostly noise for retrieval but its *structure* (who closed what, which CI failed) is part of the project memory. Skipping embeddings saves cost without breaking the graph.
+
+**Scope:** Embedding stage only. The bot flag (`user.is_bot`) is set at ingest and read at embed time.
+
+**Origin:** VISION.md, 2026-05-03.
+
+### Skip re-embedding on unchanged content
+
+Each embeddable node carries a `content_hash`. The embed stage skips items whose hash matches the prior embedding.
+
+**Why:** Embedding is the slowest stage. Most syncs touch metadata (labels, state) without changing body text; re-embedding all of them wastes time and compute.
+
+**Scope:** All embeddable tables. Hash is computed over the canonical text the embedder sees.
+
+**Origin:** VISION.md, 2026-05-03.
+
+---
+
+## Pipeline
+
+### Stages are independent and idempotent
+
+`fetch → normalize → persist → embed → search`. Each stage is independent and re-runnable. Re-running any stage with the same input produces the same output.
+
+**Why:** Sync failures should never require a "rollback." Idempotency makes retries cheap and lets stages run on different cadences (embed can lag fetch by hours).
+
+**Scope:** All sync code. Persistence uses upsert-by-`github_node_id`, not insert; embedding is keyed on `content_hash`; etc.
+
+**Origin:** VISION.md, 2026-05-03.
+
+### Schema applies are non-destructive
+
+`schemas.surrealql` uses `IF NOT EXISTS` everywhere. Re-running it never wipes data.
+
+**Why:** Real mirrored data will be loaded soon and is expensive to re-fetch. The skill convention of `REMOVE TABLE IF EXISTS` is appropriate for greenfield exploration; once data lives in the graph, schema apply must be safe to run repeatedly.
+
+**Scope:** `schemas.surrealql` and `src/schema/apply.ts`. Destructive migrations, when needed, get their own explicit script — never folded into apply.
+
+**Origin:** Setup plan execution, 2026-05-03.
+
+---
+
+## Scope discipline
+
+### Source code is out of scope, period
+
+No file trees, no symbols, no call graphs, no AST work. Even when an issue/PR mentions a file, we record the mention as text — we do not parse or link to source.
+
+**Why:** This is a discussion/decision mirror, not a code-mapping product. Drift in scope here would balloon the schema and the sync surface area.
+
+**Scope:** Forever. Reject feature requests that cross this line.
+
+**Origin:** VISION.md, 2026-05-03.
+
+### Read-only from GitHub's perspective
+
+We never POST/PATCH to GitHub. No comments, no labels, no closes, no webhooks registered.
+
+**Why:** Mirror semantics. Writing back is a different product with different risk and auth requirements.
+
+**Scope:** All GitHub interactions.
+
+**Origin:** VISION.md, 2026-05-03.
+
+### Defer until it hurts
+
+CLI framework, linter/formatter, retry policy beyond the obvious, observability — none of these get built until something concrete justifies them. `process.argv` is fine until the CLI surface forces a real router.
+
+**Why:** Premature infrastructure freezes choices that should stay open while the system is small.
+
+**Scope:** Tooling and infra decisions. Does not apply to data-shape decisions, where late changes are expensive (e.g., schema, hash semantics).
+
+**Origin:** Setup plan, 2026-05-03.
+
+### CLI commands manage resource lifecycle by scope, not by singleton
+
+Resources that need open/close (DB connections, HTTP keepalive pools) are acquired and released within the scope of a single command via higher-order wrappers (e.g., `withDb(fn)`), not via module-level singletons.
+
+**Why:** Each CLI invocation is short-lived and self-contained. Singletons push cleanup responsibility onto callers and leak when commands forget to close. HOF wrappers make leaking impossible by construction. When a long-running process (daemon, watcher) eventually appears, it gets its own pattern — we don't backport it onto the CLI path.
+
+**Scope:** All Bun CLI command handlers. Does not apply to in-process daemons or test fixtures, which manage their own lifecycle.
+
+**Origin:** Issue #1, 2026-05-03.
+
+### Paginated remote reads stream by default
+
+Helpers that paginate over remote APIs (GitHub GraphQL connections, SurrealDB live queries, etc.) are async generators yielding items as they arrive. Collect-all variants are only added when a concrete caller needs the full set in memory and can justify the cost.
+
+**Why:** Per-page memory keeps the sync path constant in repo size. Collecting before persisting is fine on `lfnovo/esperanto` and a trap on a 10k-issue repo. Idempotent persisters can flush per page.
+
+**Scope:** All fetch/sync code that talks to external paginated APIs. Does not constrain in-memory transforms after persistence.
+
+**Origin:** Issue #1, 2026-05-03.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,85 @@
+# CLAUDE.md
+
+Guidance for Claude (and harny) when working in this repo.
+
+## What this is
+
+`github-embedder-surrealdb` is a read-only GitHub knowledge-base mirror, stored as a graph in SurrealDB and exposed as a Bun CLI. It mirrors **discussion artifacts** of one or more GitHub repos — issues, PRs, discussions, comments, and PR-referenced commits — so an AI agent can semantically retrieve project memory ("what has already been discussed, decided, or attempted here").
+
+Primary consumer is **AI agents** invoked via Claude Code hooks. Cold-start latency is a first-class concern.
+
+For the full vision (purpose, scope, graph model, sync strategy, open questions): see `VISION.md`.
+
+## Read these before changing anything
+
+1. **`ARCHITECTURE.md`** — accumulated architectural principles. The principle store. Anything that touches lifecycle, edges, ingest stages, embedding, or failure handling has a relevant principle there. Not optional.
+2. **`VISION.md`** — the product vision. What the CLI does, what's in/out of scope, why the data model looks the way it does.
+3. **The closest existing implementation.** The codebase favors single-file modules per concept (`src/clients/<x>.ts`, `src/ingest/<entity>.ts`, `src/commands/<name>.ts`). Mirror what's already there before inventing patterns.
+
+## Stack
+
+- **Runtime**: Bun (single binary; `bun build --compile` is the distribution target).
+- **Language**: TypeScript, `strict: true`, `moduleResolution: "bundler"`, no emit (`bun run` direct).
+- **Storage**: SurrealDB on `localhost:8018` (namespace `githubembed`, db `main`, root/root in dev).
+- **GitHub API**: `@octokit/graphql` v9. **GraphQL only**, no REST mixing.
+- **Embeddings**: Ollama on `localhost:11434`, model `nomic-embed-text`, 768-dim. Hard schema decision.
+- **Validation**: Zod (env, GraphQL payloads).
+
+No CLI framework, no logger, no HTTP client beyond `fetch`. Per the "defer until it hurts" principle in `ARCHITECTURE.md`.
+
+## Repo layout
+
+```
+src/
+  index.ts              # argv dispatcher (hand-rolled)
+  config.ts             # zod-validated env loader
+  clients/              # reusable connections (surreal, ollama, github)
+  commands/             # one file per `tool <name>` command
+  ingest/               # one file per entity (issue, pull_request, ...) + shared helpers
+  smoke/                # manual external-infra reachability checks (NOT bun test)
+  test_utils/           # in-memory test helpers
+schemas.surrealql       # full schema, idempotent, never destructive
+ARCHITECTURE.md         # principle store
+VISION.md               # product vision
+QUERIES.md              # documented SurrealQL examples (lands with #12)
+README.md               # project overview + Testing conventions
+```
+
+## Validator
+
+The canonical validator for any change:
+
+```
+bun run typecheck && bun test
+```
+
+Both must exit 0. CI (when it exists) will run the same.
+
+Smoke tests (`bun run smoke:*`) are **manual** — they require live SurrealDB, Ollama, and `GITHUB_TOKEN`. Don't run them inside isolated worktrees and don't add them to the validator chain.
+
+## Conventions
+
+- **Co-located tests**: `*.test.ts` next to the source file. No separate `tests/` tree.
+- **In-memory infra in tests**: SurrealDB tests use `withTestDb` (in-memory `mem://`); GitHub calls are mocked via `mock.module` from `bun:test`. Don't connect to localhost SurrealDB or hit live GitHub from tests.
+- **One file per concept** until it crosses ~300 lines. Then split.
+- **Logs**: `console.log` / `console.error` with `✓` / `✗` / `!` prefixes. No logger.
+- **Read-style commands ship `--json` from day one** (per `ARCHITECTURE.md`). Action commands (`add`, `sync`, `embed`, etc.) emit human progress text only.
+- **Schema applies are non-destructive**: `IF NOT EXISTS` everywhere in `schemas.surrealql`. Real data lives there; do not add `REMOVE TABLE` statements.
+
+## Where the gotchas are
+
+- **SurrealDB v2 client uses `authentication: { username, password }`** (not `auth`). The shape changed from v1; existing code uses the right one — mirror it. Verify at `node_modules/surrealdb/dist/surrealdb.d.ts` if in doubt.
+- **`references` is a reserved word in SurrealQL** — the cross-reference edge table is `references_ref` for that reason. Don't rename it back.
+- **GraphQL author union is mandatory**: every author site must use `... on User { ... } ... on Bot { ... }` so `__typename` is available for `isBot()` (per the bot detection principle).
+- **`embedded_content_hash` vs `content_hash`**: `content_hash` is computed on persist; `embedded_content_hash` is set on embed. The trigger to re-embed is `content_hash != embedded_content_hash`. Don't conflate them.
+
+## Git / PR
+
+- **Conventional commits** (`feat:`, `fix:`, `docs:`, `chore:`, `ci:`, `refactor:`).
+- **Never mention Claude or Claude Code** in commit messages or PR descriptions.
+- **PR body must include `Closes #N`** so the issue auto-closes on merge.
+- Squash-merge to `main`, delete branch.
+
+## Issue pipeline
+
+Issues flow `triage → design → develop → merged`. Each stage is owned by a corresponding skill in the `harny-dev` plugin. By the time an issue is `ready`, the body contains the full implementation spec — execution should not require re-architecting. If you find yourself making architectural choices during develop, stop and ask whether the issue needs to go back to design.

--- a/src/clients/github.ts
+++ b/src/clients/github.ts
@@ -26,9 +26,7 @@ export async function* paginate<T>(
 ): AsyncGenerator<T> {
   let cursor: string | null = null;
   while (true) {
-    const params: RequestParameters = cursor
-      ? { ...variables, after: cursor }
-      : { ...variables };
+    const params: RequestParameters = { ...variables, cursor };
     const data = await gh<unknown>(query, params);
     const connection = selectConnection(data);
     for (const node of connection.nodes) {

--- a/src/clients/github.ts
+++ b/src/clients/github.ts
@@ -1,0 +1,40 @@
+import { graphql } from "@octokit/graphql";
+import type { RequestParameters } from "@octokit/types";
+import { requireGithubToken } from "../config.ts";
+
+let _gh: typeof graphql | null = null;
+
+function getGh(): typeof graphql {
+  if (!_gh) {
+    const token = requireGithubToken();
+    _gh = graphql.defaults({ headers: { authorization: `token ${token}` } });
+  }
+  return _gh;
+}
+
+export function gh<T>(query: string, params?: RequestParameters): Promise<T> {
+  return getGh()<T>(query, params);
+}
+
+export async function* paginate<T>(
+  query: string,
+  variables: Record<string, unknown>,
+  selectConnection: (data: unknown) => {
+    nodes: T[];
+    pageInfo: { hasNextPage: boolean; endCursor: string | null };
+  },
+): AsyncGenerator<T> {
+  let cursor: string | null = null;
+  while (true) {
+    const params: RequestParameters = cursor
+      ? { ...variables, after: cursor }
+      : { ...variables };
+    const data = await gh<unknown>(query, params);
+    const connection = selectConnection(data);
+    for (const node of connection.nodes) {
+      yield node;
+    }
+    if (!connection.pageInfo.hasNextPage) break;
+    cursor = connection.pageInfo.endCursor;
+  }
+}

--- a/src/clients/ollama.ts
+++ b/src/clients/ollama.ts
@@ -1,0 +1,36 @@
+import { config } from "../config.ts";
+
+export async function embedMany(texts: string[]): Promise<number[][]> {
+  const url = `${config.OLLAMA_URL}/api/embed`;
+  const response = await fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ model: config.OLLAMA_EMBED_MODEL, input: texts }),
+  });
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`HTTP ${response.status}: ${text}`);
+  }
+
+  const data = (await response.json()) as { embeddings?: number[][] };
+  const embeddings = data.embeddings;
+  if (!Array.isArray(embeddings)) {
+    throw new Error("Response missing `embeddings` array.");
+  }
+
+  for (const vector of embeddings) {
+    if (vector.length !== config.EMBED_DIM) {
+      throw new Error(
+        `Model '${config.OLLAMA_EMBED_MODEL}' produced ${vector.length}-dim vector, expected ${config.EMBED_DIM}.`,
+      );
+    }
+  }
+
+  return embeddings;
+}
+
+export async function embed(text: string): Promise<number[]> {
+  const result = await embedMany([text]);
+  return result[0];
+}

--- a/src/clients/surreal.ts
+++ b/src/clients/surreal.ts
@@ -1,0 +1,19 @@
+import { Surreal } from "surrealdb";
+import { config } from "../config.ts";
+
+export async function withDb<T>(fn: (db: Surreal) => Promise<T>): Promise<T> {
+  const db = new Surreal();
+  await db.connect(config.SURREAL_URL, {
+    namespace: config.SURREAL_NS,
+    database: config.SURREAL_DB,
+    authentication: {
+      username: config.SURREAL_USER,
+      password: config.SURREAL_PASS,
+    },
+  });
+  try {
+    return await fn(db);
+  } finally {
+    await db.close();
+  }
+}

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -1,0 +1,7 @@
+export default function run(): void {
+  console.log("Usage: tool <command>");
+  console.log("");
+  console.log("Commands:");
+  console.log("  help    Show this help message");
+  process.exit(0);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,13 +7,13 @@ if (cmd === undefined || cmd === "--help" || cmd === "-h") {
   const { default: run } = await import("./commands/help.ts");
   run();
 } else {
+  let mod: { default: (args: string[]) => unknown };
   try {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const mod = (await import(`./commands/${cmd}.ts`)) as { default: (...args: any[]) => unknown };
-    mod.default(argv.slice(1));
+    mod = (await import(`./commands/${cmd}.ts`)) as typeof mod;
   } catch {
     console.error(`Unknown command: ${cmd}`);
     console.error("Try: tool --help");
     process.exit(1);
   }
+  await mod.default(argv.slice(1));
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,19 @@
 #!/usr/bin/env bun
-console.log("github-embedder-surrealdb — stub entry. Setup phase.");
+
+const argv = process.argv.slice(2);
+const cmd = argv[0];
+
+if (cmd === undefined || cmd === "--help" || cmd === "-h") {
+  const { default: run } = await import("./commands/help.ts");
+  run();
+} else {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const mod = (await import(`./commands/${cmd}.ts`)) as { default: (...args: any[]) => unknown };
+    mod.default(argv.slice(1));
+  } catch {
+    console.error(`Unknown command: ${cmd}`);
+    console.error("Try: tool --help");
+    process.exit(1);
+  }
+}

--- a/src/smoke/github.ts
+++ b/src/smoke/github.ts
@@ -1,11 +1,4 @@
-import { graphql } from "@octokit/graphql";
-import { requireGithubToken } from "../config.ts";
-
-const token = requireGithubToken();
-
-const gh = graphql.defaults({
-  headers: { authorization: `token ${token}` },
-});
+import { gh } from "../clients/github.ts";
 
 const query = `
   query($owner: String!, $name: String!) {

--- a/src/smoke/ollama.ts
+++ b/src/smoke/ollama.ts
@@ -1,40 +1,13 @@
 import { config } from "../config.ts";
-
-const url = `${config.OLLAMA_URL}/api/embed`;
-const body = {
-  model: config.OLLAMA_EMBED_MODEL,
-  input: "hello world",
-};
+import { embedMany } from "../clients/ollama.ts";
 
 try {
-  const response = await fetch(url, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(body),
-  });
-
-  if (!response.ok) {
-    const text = await response.text();
-    throw new Error(`HTTP ${response.status}: ${text}`);
-  }
-
-  const data = (await response.json()) as { embeddings?: number[][] };
-  const vector = data.embeddings?.[0];
-  if (!Array.isArray(vector)) {
-    throw new Error("Response missing `embeddings[0]` array.");
-  }
-  if (vector.length !== config.EMBED_DIM) {
-    throw new Error(
-      `Expected ${config.EMBED_DIM}-dim vector, got ${vector.length}-dim. ` +
-        `Model '${config.OLLAMA_EMBED_MODEL}' produces a different dimension.`,
-    );
-  }
+  const embeddings = await embedMany(["hello world"]);
+  const vector = embeddings[0];
 
   console.log("✓ Ollama embedder reachable.");
-  console.log(`  url=${url}`);
-  console.log(
-    `  model=${config.OLLAMA_EMBED_MODEL} dim=${vector.length}`,
-  );
+  console.log(`  url=${config.OLLAMA_URL}/api/embed`);
+  console.log(`  model=${config.OLLAMA_EMBED_MODEL} dim=${vector.length}`);
   process.exit(0);
 } catch (err) {
   console.error("✗ Ollama smoke test failed.");

--- a/src/smoke/surreal.ts
+++ b/src/smoke/surreal.ts
@@ -1,28 +1,17 @@
-import { Surreal } from "surrealdb";
 import { config } from "../config.ts";
-
-const db = new Surreal();
+import { withDb } from "../clients/surreal.ts";
 
 try {
-  await db.connect(config.SURREAL_URL, {
-    namespace: config.SURREAL_NS,
-    database: config.SURREAL_DB,
-    authentication: {
-      username: config.SURREAL_USER,
-      password: config.SURREAL_PASS,
-    },
+  await withDb(async (db) => {
+    const info = await db.query("INFO FOR DB");
+    const dbInfo = (info?.[0] ?? {}) as Record<string, unknown>;
+    const keys = Object.keys(dbInfo);
+
+    console.log("✓ SurrealDB reachable.");
+    console.log(`  url=${config.SURREAL_URL}`);
+    console.log(`  namespace=${config.SURREAL_NS} database=${config.SURREAL_DB}`);
+    console.log(`  INFO FOR DB sections: ${keys.join(", ") || "(empty db)"}`);
   });
-
-  const info = await db.query("INFO FOR DB");
-  const dbInfo = (info?.[0] ?? {}) as Record<string, unknown>;
-  const keys = Object.keys(dbInfo);
-
-  console.log("✓ SurrealDB reachable.");
-  console.log(`  url=${config.SURREAL_URL}`);
-  console.log(`  namespace=${config.SURREAL_NS} database=${config.SURREAL_DB}`);
-  console.log(`  INFO FOR DB sections: ${keys.join(", ") || "(empty db)"}`);
-
-  await db.close();
   process.exit(0);
 } catch (err) {
   console.error("✗ SurrealDB smoke test failed.");


### PR DESCRIPTION
## Summary

Foundations for the CLI: shared clients (`withDb`, `gh` + `paginate`, `embed` + `embedMany`), an argv-based dispatcher with `--help` / unknown-command handling, and a refactor of the three smoke tests onto the new clients (no behavior change). No new runtime dependencies. No real commands beyond a `help` stub — those land in #2 and beyond.

Implements all decisions captured in the issue spec and `ARCHITECTURE.md`:
- `withDb<T>(fn)` HOF for SurrealDB lifecycle (per "CLI commands manage resource lifecycle by scope").
- `paginate<T>` async generator (per "Paginated remote reads stream by default").
- `embedMany` is the source of truth; `embed` delegates. Both validate 768-dim with model name in error message.
- Hand-rolled `process.argv[2]` switch — no CLI framework.

## Code-review patches on top of harny's output

Two small fixes applied after harny's developer phase passed validator:

1. `paginate` was injecting an `after` variable into GraphQL parameters; spec says `cursor` (matches the `$cursor: String` variable used by every fetcher query designed in #3–#7). Renamed.
2. `src/index.ts` had a single `try { import + run } catch` block, which would have masked errors thrown by command handlers as "Unknown command." Narrowed the catch to wrap only the dynamic import.

Both patches verified manually (typecheck + dispatcher exercises help / no-args / bogus-cmd).

## Test plan

- [x] `bun run typecheck` — clean.
- [x] `bun run src/index.ts` (no args) → prints help, exits 0.
- [x] `bun run src/index.ts --help` → prints help, exits 0.
- [x] `bun run src/index.ts bogus` → "Unknown command" on stderr, exits 1.
- [x] Smoke tests still typecheck and read more concisely (boilerplate removed).
- [ ] `bun run smoke:*` (manual; requires `.env` + live infra — not run in CI / harny worktree).

Closes #1
