### PR TITLE
feat: test harness — bun test, withTestDb, README conventions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,63 @@
+`github-embedder-surrealdb` is a read-only GitHub knowledge-base mirror stored as a graph in SurrealDB and exposed as a Bun CLI. It mirrors discussion artifacts of one or more GitHub repositories — issues, PRs, discussions, comments, and PR-referenced commits — so an AI agent can semantically retrieve project memory about what has already been discussed, decided, or attempted.
+
+## Testing
+
+### Running tests
+
+```sh
+# Run the full test suite
+bun test
+
+# Run a single test file
+bun test src/ingest/crossrefs.test.ts
+```
+
+### File location convention
+
+Tests are co-located with their source files as `*.test.ts`. There is no separate `tests/` directory. Each module owns its test alongside it (e.g., `src/ingest/crossrefs.ts` is tested by `src/ingest/crossrefs.test.ts`).
+
+### Three tiers
+
+**Unit** — Pure logic with no I/O. Tested with plain `bun test`. No database, no network. Example: `extractReferences` in `src/ingest/crossrefs.test.ts`.
+
+**Integration** — Tests that exercise real infrastructure using in-memory substitutes. SurrealDB tests use `withTestDb` (in-memory `mem://` engine via `@surrealdb/wasm`). GitHub API calls are intercepted with `mock.module` from `bun:test`. These run in CI alongside unit tests.
+
+**Smoke** — Manual checks against live external services (SurrealDB on localhost, Ollama, GitHub API). Run via `bun run smoke:surreal`, `bun run smoke:ollama`, `bun run smoke:github`. Require a real `GITHUB_TOKEN` and running services. Never included in the `bun test` chain.
+
+### Mocking the GitHub client
+
+Use `mock.module` from `bun:test` to intercept `src/clients/github.ts` before importing the module under test:
+
+```typescript
+import { mock } from "bun:test";
+
+mock.module("../../clients/github.ts", () => ({
+  fetchIssues: async () => [{ number: 1, title: "Test issue", body: "" }],
+}));
+
+// Import after mock is registered
+const { ingestIssues } = await import("./issues.ts");
+```
+
+### Using `withTestDb`
+
+`withTestDb` spins up a fresh in-memory SurrealDB instance with the full schema applied, runs your callback, then tears it down:
+
+```typescript
+import { withTestDb } from "../test_utils/with_test_db.ts";
+
+it("persists and retrieves a repo", async () => {
+  const name = await withTestDb(async (db) => {
+    await db.query(`CREATE repo:test CONTENT { name: "my-repo", ... }`);
+    const [[row]] = await db.query<[[{ name: string }]]>("SELECT name FROM repo:test");
+    return row.name;
+  });
+  expect(name).toBe("my-repo");
+});
+```
+
+Each `withTestDb` call is isolated — data does not persist across calls.
+
+### Recording fixtures
+
+For GraphQL responses from GitHub, capture a real API response once using `bun run smoke:github` or a `curl`/`gh api` call, then save the JSON to a `fixtures/` directory next to the test. Load it with `readFileSync` and return it from `mock.module`. This keeps tests fast and deterministic without requiring a live token. Re-record when the query shape changes.

--- a/bun.lock
+++ b/bun.lock
@@ -10,6 +10,7 @@
         "zod": "^4.3.6",
       },
       "devDependencies": {
+        "@surrealdb/wasm": "^3.0.3",
         "@types/bun": "^1.3.13",
         "typescript": "^6.0.3",
       },
@@ -29,6 +30,8 @@
     "@octokit/types": ["@octokit/types@16.0.0", "", { "dependencies": { "@octokit/openapi-types": "^27.0.0" } }, "sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg=="],
 
     "@surrealdb/cbor": ["@surrealdb/cbor@2.0.0-alpha.4", "", {}, "sha512-l/hNZ3ZCOJq8rzwx1y5ZV/8b2bYCWdhGqRVY33Pu50NAHyAW5qLsMn3ZBkZow77mAKwNCsbDsRGnyYEuU95mjw=="],
+
+    "@surrealdb/wasm": ["@surrealdb/wasm@3.0.3", "", { "peerDependencies": { "surrealdb": "^2.0.1" } }, "sha512-7tUOiQB2eZY80oNKfLvwqZLgANun04ubKXqfanAZmAnwJMB/nKetk7eh6dRd+PFzmLla1Ns2m6Fku+H/DSFjbA=="],
 
     "@types/bun": ["@types/bun@1.3.13", "", { "dependencies": { "bun-types": "1.3.13" } }, "sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw=="],
 

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "zod": "^4.3.6"
   },
   "devDependencies": {
+    "@surrealdb/wasm": "^3.0.3",
     "@types/bun": "^1.3.13",
     "typescript": "^6.0.3"
   }

--- a/src/ingest/crossrefs.test.ts
+++ b/src/ingest/crossrefs.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "bun:test";
+import { extractReferences } from "./crossrefs.ts";
+
+describe("extractReferences", () => {
+  it("extracts a same-repo #N mention", () => {
+    expect(extractReferences("See #5")).toEqual([
+      { owner: null, repo: null, number: 5, isClosing: false },
+    ]);
+  });
+
+  it("extracts a cross-repo owner/repo#N mention", () => {
+    expect(extractReferences("See other/project#12")).toEqual([
+      { owner: "other", repo: "project", number: 12, isClosing: false },
+    ]);
+  });
+
+  it("sets isClosing for Fixes keyword", () => {
+    expect(extractReferences("Fixes #3")).toEqual([
+      { owner: null, repo: null, number: 3, isClosing: true },
+    ]);
+  });
+
+  it("sets isClosing for Closes keyword", () => {
+    expect(extractReferences("Closes #3")).toEqual([
+      { owner: null, repo: null, number: 3, isClosing: true },
+    ]);
+  });
+
+  it("sets isClosing for Resolves keyword", () => {
+    expect(extractReferences("Resolves #3")).toEqual([
+      { owner: null, repo: null, number: 3, isClosing: true },
+    ]);
+  });
+
+  it("skips references inside fenced code blocks", () => {
+    expect(extractReferences("```\n#4\n```")).toEqual([]);
+  });
+
+  it("skips references inside URLs", () => {
+    expect(extractReferences("https://github.com/foo/bar#1")).toEqual([]);
+  });
+
+  it("skips self-references", () => {
+    expect(
+      extractReferences("#42", { owner: "a", name: "b", number: 42 })
+    ).toEqual([]);
+  });
+
+  it("deduplicates repeated same-repo references", () => {
+    expect(extractReferences("#5 and #5 again")).toEqual([
+      { owner: null, repo: null, number: 5, isClosing: false },
+    ]);
+  });
+});

--- a/src/ingest/crossrefs.ts
+++ b/src/ingest/crossrefs.ts
@@ -1,0 +1,52 @@
+// TODO(#8): full implementation per issue #8
+
+export type CrossRef = {
+  owner: string | null;
+  repo: string | null;
+  number: number;
+  isClosing: boolean;
+};
+
+export function extractReferences(
+  body: string,
+  context?: { owner: string; name: string; number: number }
+): CrossRef[] {
+  // Strip fenced code blocks
+  let text = body.replace(/```[\s\S]*?```/g, "");
+  // Strip URLs
+  text = text.replace(/https?:\/\/\S+/g, "");
+
+  const results: CrossRef[] = [];
+  const seen = new Set<string>();
+  const closingKeyword = /(?:Fixes|Closes|Resolves)\s+$/i;
+
+  // Cross-repo: owner/repo#N
+  const crossRepoRe = /\b([\w-]+)\/([\w.-]+)#(\d+)\b/g;
+  let m: RegExpExecArray | null;
+  while ((m = crossRepoRe.exec(text)) !== null) {
+    const owner = m[1];
+    const repo = m[2];
+    const num = parseInt(m[3], 10);
+    const isClosing = closingKeyword.test(text.slice(0, m.index));
+    const key = `${owner}/${repo}#${num}`;
+    if (!seen.has(key)) {
+      seen.add(key);
+      results.push({ owner, repo, number: num, isClosing });
+    }
+  }
+
+  // Same-repo: #N (not part of a cross-repo pattern or URL path)
+  const sameRepoRe = /(?<![/\w])#(\d+)\b/g;
+  while ((m = sameRepoRe.exec(text)) !== null) {
+    const num = parseInt(m[1], 10);
+    if (context && context.number === num) continue;
+    const isClosing = closingKeyword.test(text.slice(0, m.index));
+    const key = `null/null#${num}`;
+    if (!seen.has(key)) {
+      seen.add(key);
+      results.push({ owner: null, repo: null, number: num, isClosing });
+    }
+  }
+
+  return results;
+}

--- a/src/test_utils/with_test_db.test.ts
+++ b/src/test_utils/with_test_db.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from "bun:test";
+import { withTestDb } from "./with_test_db.ts";
+
+describe("withTestDb", () => {
+  it("round-trips a record through the in-memory schema", async () => {
+    const login = await withTestDb(async (db) => {
+      await db.query(`
+        CREATE org:testorg CONTENT {
+          github_node_id: "U_test",
+          github_url: "https://github.com/testorg",
+          login: "testorg",
+          name: "Test Org",
+          kind: "Organization",
+          created_at: time::now(),
+          updated_at: time::now(),
+          deleted_at: NONE
+        }
+      `);
+      const [[record]] = await db.query<[[{ login: string }]]>(
+        "SELECT login FROM org:testorg"
+      );
+      return record.login;
+    });
+
+    expect(login).toBe("testorg");
+  });
+});

--- a/src/test_utils/with_test_db.ts
+++ b/src/test_utils/with_test_db.ts
@@ -1,0 +1,18 @@
+import { Surreal, createRemoteEngines } from "surrealdb";
+import { createWasmEngines } from "@surrealdb/wasm";
+import { readFileSync } from "fs";
+
+const schema = readFileSync(import.meta.dir + "/../../schemas.surrealql", "utf-8");
+
+export async function withTestDb<T>(fn: (db: Surreal) => Promise<T>): Promise<T> {
+  const db = new Surreal({
+    engines: { ...createRemoteEngines(), ...createWasmEngines() },
+  });
+  await db.connect("mem://", { namespace: "test", database: "test" });
+  await db.query(schema);
+  try {
+    return await fn(db);
+  } finally {
+    await db.close();
+  }
+}


### PR DESCRIPTION
## Summary

Test harness for the project: `bun test` runner with co-located `*.test.ts` files, an in-memory SurrealDB helper (`withTestDb`) for integration tests, a seed unit-test suite for cross-references (validates the conventions end-to-end), and a `Testing` section in `README.md` documenting the three tiers (unit / integration / smoke), the `mock.module` pattern for the GitHub client, and how to record fixtures.

`src/ingest/crossrefs.ts` ships only as a placeholder with a `// TODO(#8)` marker — just enough behavior to make the seed tests pass. #8 owns the canonical implementation.

One dev dependency added: `@surrealdb/wasm@3.0.3`. The v2 SurrealDB JS SDK has no built-in in-memory engine — the wasm package provides it. Runtime dependencies untouched, so the production binary is unaffected.

## Test plan

- [x] `bun install --frozen-lockfile` clean (1 package added: `@surrealdb/wasm@3.0.3`).
- [x] `bun run typecheck` — clean.
- [x] `bun test` — 10/10 pass across `src/ingest/crossrefs.test.ts` (9 cases) and `src/test_utils/with_test_db.test.ts` (1 case).
- [x] Round-trip in `with_test_db.test.ts` exercises the schema apply (`schemas.surrealql`) against the in-memory engine.
- [ ] `bun run smoke:*` (manual; unaffected by this PR).

## Notes

- Seed test cases match the spec from issue #13: same-repo `#N`, cross-repo `owner/repo#N`, closing keywords (`Fixes` / `Closes` / `Resolves`), code-block skip, URL skip, self-reference skip, dedupe.
- README's `Testing` section is the canonical doc; future feature PRs follow these conventions.

Closes #13


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduce a test harness with `bun test`, co-located `*.test.ts`, and an in-memory SurrealDB helper (`withTestDb`) for fast unit/integration tests. Adds seed cross-reference tests and a minimal `extractReferences` implementation; updates README with testing conventions. Closes #13.

- **New Features**
  - `withTestDb`: spins up an isolated in-memory SurrealDB (`mem://` via `@surrealdb/wasm`) with schema applied.
  - Seed cross-reference tests per #13: same-repo `#N`, `owner/repo#N`, closing keywords, skip in code/URLs, self-skip, dedupe; `src/ingest/crossrefs.ts` has a placeholder with `// TODO(#8)`.
  - README “Testing” section: co-located tests, unit/integration/smoke tiers, `mock.module` pattern, and fixture recording notes.

- **Dependencies**
  - Add dev-only `@surrealdb/wasm@3.0.3` for the in-memory engine; runtime dependencies unchanged.

<sup>Written for commit 42df132f0e38f75914d4b5cce407486807612d70. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

