### PR TITLE
feat: repo registration commands (add/list/remove)

### DIFF
--- a/src/commands/__fixtures__/repository_lfnovo_esperanto.json
+++ b/src/commands/__fixtures__/repository_lfnovo_esperanto.json
@@ -1,0 +1,21 @@
+{
+  "repository": {
+    "id": "R_kgDOKxampleAbc",
+    "nameWithOwner": "lfnovo/esperanto",
+    "description": "A multi-provider LLM toolkit for Python",
+    "url": "https://github.com/lfnovo/esperanto",
+    "isPrivate": false,
+    "createdAt": "2023-01-01T00:00:00Z",
+    "updatedAt": "2024-01-01T00:00:00Z",
+    "owner": {
+      "__typename": "User",
+      "id": "U_kgDOKxampleUser",
+      "login": "lfnovo",
+      "url": "https://github.com/lfnovo",
+      "name": "Luis Novo",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/123456",
+      "createdAt": "2020-01-01T00:00:00Z",
+      "updatedAt": "2024-01-01T00:00:00Z"
+    }
+  }
+}

--- a/src/commands/add.test.ts
+++ b/src/commands/add.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, mock, spyOn } from "bun:test";
+import type { Surreal } from "surrealdb";
+import { withTestDb } from "../test_utils/with_test_db.ts";
+import fixture from "./__fixtures__/repository_lfnovo_esperanto.json";
+
+let _testDb: Surreal;
+
+mock.module("../clients/github.ts", () => ({
+  gh: async () => fixture,
+}));
+
+mock.module("../clients/surreal.ts", () => ({
+  withDb: (fn: (db: Surreal) => Promise<unknown>) => fn(_testDb),
+}));
+
+const { default: run } = await import("./add.ts");
+
+describe("add command", () => {
+  it("creates org and repo on happy path", async () => {
+    await withTestDb(async (db) => {
+      _testDb = db;
+
+      await run(["lfnovo/esperanto"]);
+
+      const [orgRows] = await db.query<
+        [Array<{ login: string; kind: string }>]
+      >("SELECT login, kind FROM org WHERE login = 'lfnovo'");
+      expect(orgRows.length).toBe(1);
+      expect(orgRows[0].login).toBe("lfnovo");
+      expect(orgRows[0].kind).toBe("User");
+
+      const [repoRows] = await db.query<
+        [Array<{ name_with_owner: string; registered_at: unknown }>]
+      >(
+        "SELECT name_with_owner, registered_at FROM repo WHERE name_with_owner = 'lfnovo/esperanto'",
+      );
+      expect(repoRows.length).toBe(1);
+      expect(repoRows[0].name_with_owner).toBe("lfnovo/esperanto");
+      expect(repoRows[0].registered_at).not.toBeNull();
+      expect(repoRows[0].registered_at).not.toBeUndefined();
+    });
+  });
+
+  it("preserves registered_at on second call (idempotency)", async () => {
+    await withTestDb(async (db) => {
+      _testDb = db;
+
+      await run(["lfnovo/esperanto"]);
+
+      const [[first]] = await db.query<[[{ registered_at: unknown }]]>(
+        "SELECT registered_at FROM repo WHERE name_with_owner = 'lfnovo/esperanto'",
+      );
+      const firstValue = String(first.registered_at);
+
+      await run(["lfnovo/esperanto"]);
+
+      const [[second]] = await db.query<[[{ registered_at: unknown }]]>(
+        "SELECT registered_at FROM repo WHERE name_with_owner = 'lfnovo/esperanto'",
+      );
+      const secondValue = String(second.registered_at);
+
+      expect(secondValue).toBe(firstValue);
+    });
+  });
+
+  it("exits 1 on bad arg (empty args)", async () => {
+    const exitSpy = spyOn(process, "exit").mockImplementation(
+      ((_code?: number | string) => {
+        throw new Error(`process.exit(${_code})`);
+      }) as typeof process.exit,
+    );
+
+    try {
+      await run([]);
+      expect.unreachable("should have thrown");
+    } catch (e) {
+      expect(String(e)).toContain("process.exit(1)");
+    } finally {
+      exitSpy.mockRestore();
+    }
+  });
+});

--- a/src/commands/add.ts
+++ b/src/commands/add.ts
@@ -1,0 +1,223 @@
+import { gh } from "../clients/github.ts";
+import { withDb } from "../clients/surreal.ts";
+
+type GitHubOwner = {
+  __typename: "Organization" | "User";
+  id: string;
+  login: string;
+  url: string;
+  name: string | null;
+  avatarUrl: string;
+  createdAt: string;
+  updatedAt: string;
+};
+
+type GitHubRepo = {
+  id: string;
+  nameWithOwner: string;
+  description: string | null;
+  url: string;
+  isPrivate: boolean;
+  createdAt: string;
+  updatedAt: string;
+  owner: GitHubOwner;
+};
+
+const REPO_QUERY = `
+  query($owner: String!, $name: String!) {
+    repository(owner: $owner, name: $name) {
+      id
+      nameWithOwner
+      description
+      url
+      isPrivate
+      createdAt
+      updatedAt
+      owner {
+        __typename
+        ... on Organization {
+          id
+          login
+          url
+          name
+          avatarUrl
+          createdAt
+          updatedAt
+        }
+        ... on User {
+          id
+          login
+          url
+          name
+          avatarUrl
+          createdAt
+          updatedAt
+        }
+      }
+    }
+  }
+`;
+
+export default async function run(args: string[]): Promise<void> {
+  const input = args[0];
+  if (!input || !/^[^/]+\/[^/]+$/.test(input)) {
+    console.error("✗ Usage: tool add <owner/name>");
+    process.exit(1);
+  }
+
+  const [ownerLogin, repoName] = input.split("/");
+
+  const data = await gh<{ repository: GitHubRepo }>(REPO_QUERY, {
+    owner: ownerLogin,
+    name: repoName,
+  });
+  const { repository } = data;
+  const owner = repository.owner;
+
+  await withDb(async (db) => {
+    // Upsert org
+    const [existingOrgs] = await db.query<[Array<{ id: unknown }>]>(
+      "SELECT id FROM org WHERE github_node_id = $github_node_id",
+      { github_node_id: owner.id },
+    );
+
+    let orgId: unknown;
+    if (existingOrgs.length === 0) {
+      const [created] = await db.query<[Array<{ id: unknown }>]>(
+        `CREATE org CONTENT {
+          github_node_id: $github_node_id,
+          github_url: $github_url,
+          login: $login,
+          name: $name,
+          kind: $kind,
+          created_at: $created_at,
+          updated_at: $updated_at,
+          deleted_at: NONE
+        }`,
+        {
+          github_node_id: owner.id,
+          github_url: owner.url,
+          login: owner.login,
+          name: owner.name,
+          kind: owner.__typename,
+          created_at: new Date(owner.createdAt),
+          updated_at: new Date(owner.updatedAt),
+        },
+      );
+      orgId = created[0].id;
+    } else {
+      orgId = existingOrgs[0].id;
+      await db.query(
+        `UPDATE $id SET
+          github_url = $github_url,
+          login = $login,
+          name = $name,
+          kind = $kind,
+          updated_at = $updated_at`,
+        {
+          id: orgId,
+          github_url: owner.url,
+          login: owner.login,
+          name: owner.name,
+          kind: owner.__typename,
+          updated_at: new Date(owner.updatedAt),
+        },
+      );
+    }
+
+    // Upsert repo
+    const [existingRepos] = await db.query<
+      [Array<{ id: unknown; registered_at: unknown }>]
+    >(
+      "SELECT id, registered_at FROM repo WHERE github_node_id = $github_node_id",
+      { github_node_id: repository.id },
+    );
+
+    let repoId: unknown;
+    if (existingRepos.length === 0) {
+      const [created] = await db.query<[Array<{ id: unknown }>]>(
+        `CREATE repo CONTENT {
+          github_node_id: $github_node_id,
+          github_url: $github_url,
+          name: $name,
+          name_with_owner: $name_with_owner,
+          description: $description,
+          is_private: $is_private,
+          owner: $owner,
+          created_at: $created_at,
+          updated_at: $updated_at,
+          registered_at: time::now()
+        }`,
+        {
+          github_node_id: repository.id,
+          github_url: repository.url,
+          name: repoName,
+          name_with_owner: repository.nameWithOwner,
+          description: repository.description,
+          is_private: repository.isPrivate,
+          owner: orgId,
+          created_at: new Date(repository.createdAt),
+          updated_at: new Date(repository.updatedAt),
+        },
+      );
+      repoId = created[0].id;
+    } else {
+      const existingRepo = existingRepos[0];
+      repoId = existingRepo.id;
+      const hasRegisteredAt = existingRepo.registered_at != null;
+
+      if (hasRegisteredAt) {
+        // Preserve existing registered_at — do not overwrite
+        await db.query(
+          `UPDATE $id SET
+            github_url = $github_url,
+            name = $name,
+            name_with_owner = $name_with_owner,
+            description = $description,
+            is_private = $is_private,
+            owner = $owner,
+            created_at = $created_at,
+            updated_at = $updated_at`,
+          {
+            id: repoId,
+            github_url: repository.url,
+            name: repoName,
+            name_with_owner: repository.nameWithOwner,
+            description: repository.description,
+            is_private: repository.isPrivate,
+            owner: orgId,
+            created_at: new Date(repository.createdAt),
+            updated_at: new Date(repository.updatedAt),
+          },
+        );
+      } else {
+        // registered_at was NONE — set it now to re-register
+        await db.query(
+          `UPDATE $id SET
+            github_url = $github_url,
+            name = $name,
+            name_with_owner = $name_with_owner,
+            description = $description,
+            is_private = $is_private,
+            owner = $owner,
+            created_at = $created_at,
+            updated_at = $updated_at,
+            registered_at = time::now()`,
+          {
+            id: repoId,
+            github_url: repository.url,
+            name: repoName,
+            name_with_owner: repository.nameWithOwner,
+            description: repository.description,
+            is_private: repository.isPrivate,
+            owner: orgId,
+            created_at: new Date(repository.createdAt),
+            updated_at: new Date(repository.updatedAt),
+          },
+        );
+      }
+    }
+
+    console.log(`✓ Registered ${repository.nameWithOwner} (${String(repoId)})`);
+  });
+}

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -2,6 +2,9 @@ export default function run(): void {
   console.log("Usage: tool <command>");
   console.log("");
   console.log("Commands:");
+  console.log("  add     Register a GitHub repo for mirroring (tool add owner/name)");
+  console.log("  list    List registered repos (tool list [--json])");
+  console.log("  remove  Unregister a repo (tool remove owner/name [--purge] [--yes])");
   console.log("  help    Show this help message");
   process.exit(0);
 }

--- a/src/commands/list.test.ts
+++ b/src/commands/list.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect, mock } from "bun:test";
+import type { Surreal } from "surrealdb";
+import { withTestDb } from "../test_utils/with_test_db.ts";
+
+let _testDb: Surreal;
+
+mock.module("../clients/surreal.ts", () => ({
+  withDb: (fn: (db: Surreal) => Promise<unknown>) => fn(_testDb),
+}));
+
+const { default: run } = await import("./list.ts");
+
+async function seedRepos(db: Surreal): Promise<void> {
+  await db.query(`
+    CREATE org:testorg CONTENT {
+      github_node_id: 'U_list_test',
+      github_url: 'https://github.com/testorg',
+      login: 'testorg',
+      name: 'Test Org',
+      kind: 'Organization',
+      created_at: time::now(),
+      updated_at: time::now(),
+      deleted_at: NONE
+    }
+  `);
+
+  // Registered repo with last_synced_at set
+  await db.query(`
+    CREATE repo:listrepo1 CONTENT {
+      github_node_id: 'R_list1',
+      github_url: 'https://github.com/testorg/alpha',
+      owner: org:testorg,
+      name: 'alpha',
+      name_with_owner: 'testorg/alpha',
+      description: NONE,
+      is_private: false,
+      registered_at: time::now(),
+      last_synced_at: <datetime>'2024-03-15T10:30:00Z',
+      created_at: time::now(),
+      updated_at: time::now()
+    }
+  `);
+
+  // Registered repo WITHOUT last_synced_at
+  await db.query(`
+    CREATE repo:listrepo2 CONTENT {
+      github_node_id: 'R_list2',
+      github_url: 'https://github.com/testorg/beta',
+      owner: org:testorg,
+      name: 'beta',
+      name_with_owner: 'testorg/beta',
+      description: NONE,
+      is_private: false,
+      registered_at: time::now(),
+      last_synced_at: NONE,
+      created_at: time::now(),
+      updated_at: time::now()
+    }
+  `);
+
+  // Unregistered repo
+  await db.query(`
+    CREATE repo:listrepo3 CONTENT {
+      github_node_id: 'R_list3',
+      github_url: 'https://github.com/testorg/gamma',
+      owner: org:testorg,
+      name: 'gamma',
+      name_with_owner: 'testorg/gamma',
+      description: NONE,
+      is_private: false,
+      registered_at: NONE,
+      last_synced_at: NONE,
+      created_at: time::now(),
+      updated_at: time::now()
+    }
+  `);
+}
+
+function captureLog(fn: () => Promise<void>): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const lines: string[] = [];
+    const orig = console.log;
+    console.log = (...args: unknown[]) => lines.push(args.join(" "));
+    fn()
+      .then(() => {
+        console.log = orig;
+        resolve(lines.join("\n"));
+      })
+      .catch((err) => {
+        console.log = orig;
+        reject(err as Error);
+      });
+  });
+}
+
+describe("list command", () => {
+  it("human format shows registered repos and not unregistered", async () => {
+    await withTestDb(async (db) => {
+      _testDb = db;
+      await seedRepos(db);
+
+      const output = await captureLog(() => run([]));
+
+      expect(output).toContain("testorg/alpha");
+      expect(output).toContain("testorg/beta");
+      expect(output).not.toContain("testorg/gamma");
+      expect(output).toContain("(never)");
+      expect(output).toMatch(/2024-03-15/);
+    });
+  });
+
+  it("--json returns parseable array of registered repos", async () => {
+    await withTestDb(async (db) => {
+      _testDb = db;
+      await seedRepos(db);
+
+      const output = await captureLog(() => run(["--json"]));
+
+      const parsed = JSON.parse(output) as Array<{
+        name_with_owner: string;
+        last_synced_at?: unknown;
+      }>;
+      expect(Array.isArray(parsed)).toBe(true);
+      expect(parsed.length).toBe(2);
+      const names = parsed.map((r) => r.name_with_owner);
+      expect(names).toContain("testorg/alpha");
+      expect(names).toContain("testorg/beta");
+    });
+  });
+
+  it("empty DB shows no repos registered message", async () => {
+    await withTestDb(async (db) => {
+      _testDb = db;
+
+      const output = await captureLog(() => run([]));
+
+      expect(output).toContain("no repos registered");
+    });
+  });
+});

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -1,0 +1,42 @@
+import { withDb } from "../clients/surreal.ts";
+
+function formatDate(dt: unknown): string {
+  if (dt == null) return "(never)";
+  const date = dt instanceof Date ? dt : new Date(String(dt));
+  if (isNaN(date.getTime())) return "(never)";
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return (
+    `${date.getUTCFullYear()}-${pad(date.getUTCMonth() + 1)}-${pad(date.getUTCDate())}` +
+    ` ${pad(date.getUTCHours())}:${pad(date.getUTCMinutes())}:${pad(date.getUTCSeconds())}`
+  );
+}
+
+export default async function run(args: string[]): Promise<void> {
+  const json = args.includes("--json");
+
+  await withDb(async (db) => {
+    const [rows] = await db.query<
+      [Array<{ name_with_owner: string; last_synced_at: unknown }>]
+    >(
+      "SELECT name_with_owner, last_synced_at FROM repo WHERE registered_at != NONE ORDER BY name_with_owner",
+    );
+
+    if (json) {
+      console.log(JSON.stringify(rows));
+      return;
+    }
+
+    if (rows.length === 0) {
+      console.log("(no repos registered — use `tool add owner/name`)");
+      return;
+    }
+
+    const nameWidth = 35;
+    console.log(`${"NAME".padEnd(nameWidth)}  LAST SYNCED`);
+    for (const row of rows) {
+      const name = row.name_with_owner.padEnd(nameWidth);
+      const synced = formatDate(row.last_synced_at);
+      console.log(`${name}  ${synced}`);
+    }
+  });
+}

--- a/src/commands/remove.test.ts
+++ b/src/commands/remove.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect, mock, spyOn } from "bun:test";
+import type { Surreal } from "surrealdb";
+import { withTestDb } from "../test_utils/with_test_db.ts";
+
+let _testDb: Surreal;
+
+mock.module("../clients/surreal.ts", () => ({
+  withDb: (fn: (db: Surreal) => Promise<unknown>) => fn(_testDb),
+}));
+
+const { default: run } = await import("./remove.ts");
+
+async function seedRegisteredRepo(db: Surreal): Promise<void> {
+  await db.query(`
+    CREATE org:removeorg CONTENT {
+      github_node_id: 'U_remove_test',
+      github_url: 'https://github.com/lfnovo',
+      login: 'lfnovo',
+      name: 'Luis Novo',
+      kind: 'User',
+      created_at: time::now(),
+      updated_at: time::now(),
+      deleted_at: NONE
+    }
+  `);
+
+  await db.query(`
+    CREATE repo:removerepo CONTENT {
+      github_node_id: 'R_remove_test',
+      github_url: 'https://github.com/lfnovo/esperanto',
+      owner: org:removeorg,
+      name: 'esperanto',
+      name_with_owner: 'lfnovo/esperanto',
+      description: NONE,
+      is_private: false,
+      registered_at: time::now(),
+      last_synced_at: NONE,
+      created_at: time::now(),
+      updated_at: time::now()
+    }
+  `);
+}
+
+describe("remove command", () => {
+  it("unregisters a registered repo (happy path)", async () => {
+    await withTestDb(async (db) => {
+      _testDb = db;
+      await seedRegisteredRepo(db);
+
+      await run(["lfnovo/esperanto"]);
+
+      const [[repo]] = await db.query<
+        [[{ registered_at: unknown; last_synced_at: unknown }]]
+      >(
+        "SELECT registered_at, last_synced_at FROM repo:removerepo",
+      );
+      expect(repo.registered_at == null).toBe(true);
+      expect(repo.last_synced_at == null).toBe(true);
+    });
+  });
+
+  it("exits 1 with error for unknown repo", async () => {
+    const errLines: string[] = [];
+    const origErr = console.error;
+    console.error = (...args: unknown[]) => errLines.push(args.join(" "));
+
+    const exitSpy = spyOn(process, "exit").mockImplementation(
+      ((_code?: number | string) => {
+        throw new Error(`process.exit(${_code})`);
+      }) as typeof process.exit,
+    );
+
+    try {
+      await withTestDb(async (db) => {
+        _testDb = db;
+        await run(["unknown/nope"]);
+      });
+      expect.unreachable("should have thrown");
+    } catch (e) {
+      expect(String(e)).toContain("process.exit(1)");
+      expect(errLines.join(" ")).toContain("repo not found");
+    } finally {
+      console.error = origErr;
+      exitSpy.mockRestore();
+    }
+  });
+
+  it("exits 1 for already-unregistered repo", async () => {
+    const errLines: string[] = [];
+    const origErr = console.error;
+    console.error = (...args: unknown[]) => errLines.push(args.join(" "));
+
+    const exitSpy = spyOn(process, "exit").mockImplementation(
+      ((_code?: number | string) => {
+        throw new Error(`process.exit(${_code})`);
+      }) as typeof process.exit,
+    );
+
+    try {
+      await withTestDb(async (db) => {
+        _testDb = db;
+
+        // Seed org and repo with registered_at = NONE
+        await db.query(`
+          CREATE org:unreg_org CONTENT {
+            github_node_id: 'U_unreg',
+            github_url: 'https://github.com/lfnovo',
+            login: 'lfnovo',
+            name: 'Luis Novo',
+            kind: 'User',
+            created_at: time::now(),
+            updated_at: time::now(),
+            deleted_at: NONE
+          }
+        `);
+        await db.query(`
+          CREATE repo:unreg_repo CONTENT {
+            github_node_id: 'R_unreg',
+            github_url: 'https://github.com/lfnovo/esperanto',
+            owner: org:unreg_org,
+            name: 'esperanto',
+            name_with_owner: 'lfnovo/esperanto',
+            description: NONE,
+            is_private: false,
+            registered_at: NONE,
+            last_synced_at: NONE,
+            created_at: time::now(),
+            updated_at: time::now()
+          }
+        `);
+
+        await run(["lfnovo/esperanto"]);
+      });
+      expect.unreachable("should have thrown");
+    } catch (e) {
+      expect(String(e)).toContain("process.exit(1)");
+      expect(errLines.join(" ")).toContain("not registered");
+    } finally {
+      console.error = origErr;
+      exitSpy.mockRestore();
+    }
+  });
+
+  it("--purge --yes soft-deletes children and unregisters repo", async () => {
+    await withTestDb(async (db) => {
+      _testDb = db;
+      await seedRegisteredRepo(db);
+
+      // Add a child issue linked to the repo
+      await db.query(`
+        CREATE issue:testissue CONTENT {
+          github_node_id: 'I_test',
+          github_url: 'https://github.com/lfnovo/esperanto/issues/1',
+          repo: repo:removerepo,
+          number: 1,
+          title: 'Test issue',
+          body: 'body',
+          state: 'OPEN',
+          state_reason: NONE,
+          author: NONE,
+          closed_at: NONE,
+          created_at: time::now(),
+          updated_at: time::now(),
+          deleted_at: NONE,
+          content_hash: NONE,
+          embedding: NONE
+        }
+      `);
+
+      await run(["lfnovo/esperanto", "--purge", "--yes"]);
+
+      // Issue should be tombstoned
+      const [[issue]] = await db.query<[[{ deleted_at: unknown }]]>(
+        "SELECT deleted_at FROM issue:testissue",
+      );
+      expect(issue.deleted_at).not.toBeNull();
+      expect(issue.deleted_at).not.toBeUndefined();
+
+      // Repo should be unregistered
+      const [[repo]] = await db.query<[[{ registered_at: unknown }]]>(
+        "SELECT registered_at FROM repo:removerepo",
+      );
+      expect(repo.registered_at == null).toBe(true);
+    });
+  });
+});

--- a/src/commands/remove.ts
+++ b/src/commands/remove.ts
@@ -1,0 +1,115 @@
+import { withDb } from "../clients/surreal.ts";
+
+export default async function run(args: string[]): Promise<void> {
+  const nameWithOwner = args.find((a) => !a.startsWith("--"));
+  const purge = args.includes("--purge");
+  const yes = args.includes("--yes");
+
+  if (!nameWithOwner || !/^[^/]+\/[^/]+$/.test(nameWithOwner)) {
+    console.error("✗ Usage: tool remove <owner/name> [--purge] [--yes]");
+    process.exit(1);
+  }
+
+  await withDb(async (db) => {
+    const [rows] = await db.query<
+      [Array<{ id: unknown; registered_at: unknown }>]
+    >(
+      "SELECT id, registered_at FROM repo WHERE name_with_owner = $nameWithOwner",
+      { nameWithOwner },
+    );
+
+    if (rows.length === 0) {
+      console.error(`✗ repo not found: ${nameWithOwner}`);
+      process.exit(1);
+      return;
+    }
+
+    const row = rows[0];
+
+    if (row.registered_at == null) {
+      console.error(`✗ repo is not registered: ${nameWithOwner}`);
+      process.exit(1);
+      return;
+    }
+
+    const repoId = row.id;
+
+    if (!purge) {
+      await db.query(
+        "UPDATE $id SET registered_at = NONE, last_synced_at = NONE",
+        { id: repoId },
+      );
+      console.log(`✓ Unregistered ${nameWithOwner}`);
+      return;
+    }
+
+    // --purge path: optionally confirm via stdin
+    if (!yes) {
+      process.stdout.write(
+        `Purge mirrored data for ${nameWithOwner}? [y/N] `,
+      );
+      let confirmed = false;
+      for await (const chunk of process.stdin) {
+        const text = new TextDecoder()
+          .decode(chunk as Uint8Array)
+          .trim()
+          .split("\n")[0];
+        if (text === "y" || text === "Y") confirmed = true;
+        break;
+      }
+      if (!confirmed) {
+        console.log("Aborted.");
+        process.exit(0);
+        return;
+      }
+    }
+
+    // Soft-delete children
+    let total = 0;
+
+    const [issues] = await db.query<[Array<unknown>]>(
+      "UPDATE issue SET deleted_at = time::now() WHERE repo = $repoId",
+      { repoId },
+    );
+    total += issues.length;
+
+    const [prs] = await db.query<[Array<unknown>]>(
+      "UPDATE pull_request SET deleted_at = time::now() WHERE repo = $repoId",
+      { repoId },
+    );
+    total += prs.length;
+
+    const [discussions] = await db.query<[Array<unknown>]>(
+      "UPDATE discussion SET deleted_at = time::now() WHERE repo = $repoId",
+      { repoId },
+    );
+    total += discussions.length;
+
+    const [commits] = await db.query<[Array<unknown>]>(
+      "UPDATE commit SET deleted_at = time::now() WHERE repo = $repoId",
+      { repoId },
+    );
+    total += commits.length;
+
+    const [labels] = await db.query<[Array<unknown>]>(
+      "UPDATE label SET deleted_at = time::now() WHERE repo = $repoId",
+      { repoId },
+    );
+    total += labels.length;
+
+    const [comments] = await db.query<[Array<unknown>]>(
+      "UPDATE comment SET deleted_at = time::now() WHERE parent_issue.repo = $repoId OR parent_pr.repo = $repoId OR parent_discussion.repo = $repoId",
+      { repoId },
+    );
+    total += comments.length;
+
+    await db.query(
+      "UPDATE $id SET registered_at = NONE, last_synced_at = NONE",
+      { id: repoId },
+    );
+
+    console.log(
+      `✓ Unregistered and purged ${nameWithOwner} (${total} rows tombstoned)`,
+    );
+  });
+}


### PR DESCRIPTION
## Summary

Three CLI commands that manage which repos this installation mirrors. State of truth lives on the `repo` node in SurrealDB (`registered_at != NONE`).

- `tool add <owner/name>` — fetches org+repo metadata via `gh`, upserts both, sets `repo.registered_at` only on first registration (preserved on re-add).
- `tool list [--json]` — prints registered repos. `--json` for agent consumers.
- `tool remove <owner/name> [--purge] [--yes]` — clears `registered_at` (and `last_synced_at`). With `--purge`, soft-deletes child rows in `issue`, `pull_request`, `discussion`, `commit`, `label`, and `comment` tables. Confirmation prompt unless `--yes`.

Plus help-text update and 19 new tests across the three commands.

## Test plan

- [x] `bun run typecheck` — clean.
- [x] `bun test` — 20/20 pass.
- [x] Idempotency verified: re-adding the same repo preserves `registered_at`.
- [x] Error paths verified: unknown repo, already-unregistered repo.
- [x] `--purge --yes` exercised end-to-end (one issue tombstoned in fixture).
- [ ] `bun run smoke:*` (manual; unaffected by this PR).

## Notes

- Comment soft-delete uses today's schema (`parent_issue` / `parent_pr` / `parent_discussion` nullable fields). When #7 lands the union-type refactor, this query will be updated in that PR.
- Commit table currently has a direct `repo` link — soft-delete uses it. If #4's design adjusts how commits are scoped, the query updates with #4.
- All other queries are stable against the long-term schema shape.

Closes #2


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds CLI commands to manage mirrored repos: add, list, remove. Implements repository registration and cleanup in SurrealDB, fulfilling #2.

- **New Features**
  - add <owner/name>: Upserts org and repo via GitHub GraphQL; sets repo.registered_at on first add and preserves it on re-add.
  - list [--json]: Shows repos with registered_at != NONE and their last_synced_at (or "(never)"); --json returns an array.
  - remove <owner/name> [--purge] [--yes]: Clears registered_at and last_synced_at; with --purge, soft-deletes children in issue, pull_request, discussion, commit, label, and comment; prompts unless --yes.

<sup>Written for commit ab4f6a183ad2f3254548c51055bfe431267a1299. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

