### PR TITLE
feat: issue fetcher + persister with shared ingest helpers

### DIFF
--- a/src/ingest/__fixtures__/issues_page_1.json
+++ b/src/ingest/__fixtures__/issues_page_1.json
@@ -1,0 +1,55 @@
+{
+  "repository": {
+    "issues": {
+      "pageInfo": { "hasNextPage": true, "endCursor": "cursor1" },
+      "nodes": [
+        {
+          "id": "I_001",
+          "url": "https://github.com/test/repo/issues/1",
+          "number": 1,
+          "title": "First Issue",
+          "body": "Body of first issue\r\nwith CRLF line endings",
+          "state": "OPEN",
+          "stateReason": null,
+          "closedAt": null,
+          "createdAt": "2026-01-01T00:00:00Z",
+          "updatedAt": "2026-01-02T00:00:00Z",
+          "author": {
+            "__typename": "User",
+            "id": "U_001",
+            "login": "testuser",
+            "url": "https://github.com/testuser"
+          },
+          "labels": {
+            "nodes": [
+              {
+                "id": "LB_001",
+                "name": "bug",
+                "color": "d73a4a",
+                "description": "Something broken"
+              }
+            ],
+            "pageInfo": { "hasNextPage": false, "endCursor": null }
+          }
+        },
+        {
+          "id": "I_002",
+          "url": "https://github.com/test/repo/issues/2",
+          "number": 2,
+          "title": "Second Issue",
+          "body": null,
+          "state": "CLOSED",
+          "stateReason": "COMPLETED",
+          "closedAt": "2026-01-03T00:00:00Z",
+          "createdAt": "2026-01-01T12:00:00Z",
+          "updatedAt": "2026-01-03T00:00:00Z",
+          "author": null,
+          "labels": {
+            "nodes": [],
+            "pageInfo": { "hasNextPage": false, "endCursor": null }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/src/ingest/__fixtures__/issues_page_2.json
+++ b/src/ingest/__fixtures__/issues_page_2.json
@@ -1,0 +1,38 @@
+{
+  "repository": {
+    "issues": {
+      "pageInfo": { "hasNextPage": false, "endCursor": null },
+      "nodes": [
+        {
+          "id": "I_003",
+          "url": "https://github.com/test/repo/issues/3",
+          "number": 3,
+          "title": "Third Issue",
+          "body": "Bot authored issue with dependencies update",
+          "state": "OPEN",
+          "stateReason": null,
+          "closedAt": null,
+          "createdAt": "2026-01-04T00:00:00Z",
+          "updatedAt": "2026-01-05T00:00:00Z",
+          "author": {
+            "__typename": "Bot",
+            "id": "B_001",
+            "login": "dependabot[bot]",
+            "url": "https://github.com/apps/dependabot"
+          },
+          "labels": {
+            "nodes": [
+              {
+                "id": "LB_002",
+                "name": "dependencies",
+                "color": "0075ca",
+                "description": null
+              }
+            ],
+            "pageInfo": { "hasNextPage": false, "endCursor": null }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/src/ingest/bot.test.ts
+++ b/src/ingest/bot.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from "bun:test";
+import { isBot } from "./bot.ts";
+
+describe("isBot", () => {
+  it("returns true for Bot typename", () => {
+    expect(isBot("Bot", "x")).toBe(true);
+  });
+
+  it("returns true for [bot] login suffix", () => {
+    expect(isBot("User", "dependabot[bot]")).toBe(true);
+  });
+
+  it("returns false for regular user", () => {
+    expect(isBot("User", "lfnovo")).toBe(false);
+  });
+});

--- a/src/ingest/bot.ts
+++ b/src/ingest/bot.ts
@@ -1,0 +1,4 @@
+// STUB: refined by #9. Stable signature.
+export function isBot(typename: "User" | "Bot", login: string): boolean {
+  return typename === "Bot" || login.endsWith("[bot]");
+}

--- a/src/ingest/issue.test.ts
+++ b/src/ingest/issue.test.ts
@@ -1,0 +1,240 @@
+import { describe, it, expect, mock } from "bun:test";
+import { withTestDb } from "../test_utils/with_test_db.ts";
+
+import page1 from "./__fixtures__/issues_page_1.json";
+import page2 from "./__fixtures__/issues_page_2.json";
+
+mock.module("../clients/github.ts", () => ({
+  paginate: async function* (
+    _query: string,
+    _variables: unknown,
+    selectConnection: (data: unknown) => {
+      nodes: unknown[];
+      pageInfo: { hasNextPage: boolean; endCursor: string | null };
+    },
+  ) {
+    for (const page of [page1, page2]) {
+      const connection = selectConnection(page);
+      for (const node of connection.nodes) {
+        yield node;
+      }
+    }
+  },
+  gh: async () => ({}),
+}));
+
+const { fetchIssues, persistIssue, computeContentHash } = await import("./issue.ts");
+type ParsedIssue = Parameters<typeof persistIssue>[2];
+
+// ─── 1. content_hash determinism ─────────────────────────────────────────────
+
+describe("computeContentHash", () => {
+  it("same (title, body) always produces the same hex string", () => {
+    const h1 = computeContentHash("My Title", "Some body");
+    const h2 = computeContentHash("My Title", "Some body");
+    expect(h1).toBe(h2);
+    expect(h1).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("CRLF and LF bodies produce the same hash", () => {
+    const crlfHash = computeContentHash("T", "Hello\r\nWorld");
+    const lfHash = computeContentHash("T", "Hello\nWorld");
+    expect(crlfHash).toBe(lfHash);
+  });
+
+  it("different inputs produce different hashes", () => {
+    const h1 = computeContentHash("Title A", "body");
+    const h2 = computeContentHash("Title B", "body");
+    expect(h1).not.toBe(h2);
+  });
+
+  it("null body is treated as empty string", () => {
+    const h1 = computeContentHash("T", null);
+    const h2 = computeContentHash("T", "");
+    expect(h1).toBe(h2);
+  });
+});
+
+// ─── shared repo setup ────────────────────────────────────────────────────────
+
+async function setupRepo(
+  db: Parameters<Parameters<typeof withTestDb>[0]>[0],
+  suffix: string,
+): Promise<string> {
+  const [orgRows] = await db.query<[Array<{ id: unknown }>]>(
+    `CREATE org CONTENT {
+      github_node_id: $nid,
+      github_url: $url,
+      login: $login,
+      name: $name,
+      kind: "User",
+      created_at: time::now(),
+      updated_at: time::now(),
+      deleted_at: NONE
+    }`,
+    {
+      nid: `ORG_${suffix}`,
+      url: `https://github.com/testorg${suffix}`,
+      login: `testorg${suffix}`,
+      name: `Test Org ${suffix}`,
+    },
+  );
+  const orgId = orgRows[0].id;
+
+  const [repoRows] = await db.query<[Array<{ id: unknown }>]>(
+    `CREATE repo CONTENT {
+      github_node_id: $nid,
+      github_url: $url,
+      name: "repo",
+      name_with_owner: $nwo,
+      description: NONE,
+      is_private: false,
+      owner: $orgId,
+      created_at: time::now(),
+      updated_at: time::now(),
+      deleted_at: NONE
+    }`,
+    {
+      nid: `REPO_${suffix}`,
+      url: `https://github.com/testorg${suffix}/repo`,
+      nwo: `testorg${suffix}/repo`,
+      orgId,
+    },
+  );
+  return String(repoRows[0].id);
+}
+
+// ─── 2. persistIssue idempotency ─────────────────────────────────────────────
+
+describe("persistIssue idempotency", () => {
+  it("persist same issue twice leaves exactly 1 issue, 1 user, and 1 has_label edge", async () => {
+    await withTestDb(async (db) => {
+      const repoId = await setupRepo(db, "A");
+      const repo = { id: repoId, name_with_owner: "testorgA/repo" };
+
+      const parsed: ParsedIssue = {
+        github_node_id: "I_IDEM_1",
+        github_url: "https://github.com/testorgA/repo/issues/10",
+        number: 10,
+        title: "Idempotency Test Issue",
+        body: "Some body text",
+        state: "OPEN",
+        state_reason: null,
+        closed_at: null,
+        created_at: new Date("2026-01-01T00:00:00Z"),
+        updated_at: new Date("2026-01-02T00:00:00Z"),
+        content_hash: computeContentHash("Idempotency Test Issue", "Some body text"),
+        author: {
+          github_node_id: "U_IDEM_1",
+          login: "testuser",
+          is_bot: false,
+          github_url: "https://github.com/testuser",
+        },
+        labels: [
+          { github_node_id: "LB_IDEM_1", name: "bug", color: "d73a4a", description: "A bug" },
+        ],
+      };
+
+      await persistIssue(db, repo, parsed);
+      await persistIssue(db, repo, parsed);
+
+      const [issueRows] = await db.query<[Array<unknown>]>("SELECT id FROM issue");
+      expect(issueRows.length).toBe(1);
+
+      const [userRows] = await db.query<[Array<unknown>]>("SELECT id FROM user");
+      expect(userRows.length).toBe(1);
+
+      const [edgeRows] = await db.query<[Array<unknown>]>("SELECT id FROM has_label");
+      expect(edgeRows.length).toBe(1);
+    });
+  });
+});
+
+// ─── 3. author: null path ─────────────────────────────────────────────────────
+
+describe("persistIssue author: null", () => {
+  it("stores author as NONE and creates no user rows", async () => {
+    await withTestDb(async (db) => {
+      const repoId = await setupRepo(db, "B");
+      const repo = { id: repoId, name_with_owner: "testorgB/repo" };
+
+      const parsed: ParsedIssue = {
+        github_node_id: "I_NULL_AUTH",
+        github_url: "https://github.com/testorgB/repo/issues/5",
+        number: 5,
+        title: "No Author Issue",
+        body: "",
+        state: "CLOSED",
+        state_reason: "COMPLETED",
+        closed_at: new Date("2026-01-10T00:00:00Z"),
+        created_at: new Date("2026-01-01T00:00:00Z"),
+        updated_at: new Date("2026-01-10T00:00:00Z"),
+        content_hash: computeContentHash("No Author Issue", ""),
+        author: null,
+        labels: [],
+      };
+
+      await persistIssue(db, repo, parsed);
+
+      const [isNoneRows] = await db.query<[Array<{ is_none: boolean }>]>(
+        "SELECT author IS NONE AS is_none FROM issue WHERE github_node_id = $id",
+        { id: "I_NULL_AUTH" },
+      );
+      expect(isNoneRows.length).toBe(1);
+      expect(isNoneRows[0].is_none).toBe(true);
+
+      const [userRows] = await db.query<[Array<unknown>]>("SELECT id FROM user");
+      expect(userRows.length).toBe(0);
+    });
+  });
+});
+
+// ─── 4. fetchIssues mock ──────────────────────────────────────────────────────
+
+describe("fetchIssues mock", () => {
+  it("yields all issues from both fixture pages with correct shape", async () => {
+    const issues: ParsedIssue[] = [];
+    for await (const issue of fetchIssues("test", "repo")) {
+      issues.push(issue);
+    }
+
+    expect(issues.length).toBe(3);
+
+    const ids = issues.map((i) => i.github_node_id);
+    expect(ids).toContain("I_001");
+    expect(ids).toContain("I_002");
+    expect(ids).toContain("I_003");
+
+    for (const issue of issues) {
+      expect(issue.content_hash).toMatch(/^[0-9a-f]{64}$/);
+    }
+
+    const issue1 = issues.find((i) => i.github_node_id === "I_001")!;
+    expect(issue1.state).toBe("OPEN");
+    expect(issue1.author).not.toBeNull();
+    expect(issue1.author?.login).toBe("testuser");
+    expect(issue1.labels.length).toBe(1);
+    expect(issue1.labels[0].name).toBe("bug");
+
+    const issue2 = issues.find((i) => i.github_node_id === "I_002")!;
+    expect(issue2.state).toBe("CLOSED");
+    expect(issue2.author).toBeNull();
+    expect(issue2.labels.length).toBe(0);
+
+    const issue3 = issues.find((i) => i.github_node_id === "I_003")!;
+    expect(issue3.author).not.toBeNull();
+    expect(issue3.author?.is_bot).toBe(true);
+    expect(issue3.labels.length).toBe(1);
+    expect(issue3.labels[0].name).toBe("dependencies");
+  });
+
+  it("CRLF in fixture body is normalized to LF", async () => {
+    const issues: ParsedIssue[] = [];
+    for await (const issue of fetchIssues("test", "repo")) {
+      issues.push(issue);
+    }
+    const issue1 = issues.find((i) => i.github_node_id === "I_001")!;
+    expect(issue1.body).not.toContain("\r\n");
+    expect(issue1.body).toContain("\n");
+  });
+});

--- a/src/ingest/issue.ts
+++ b/src/ingest/issue.ts
@@ -1,0 +1,275 @@
+import { createHash } from "node:crypto";
+import { z } from "zod";
+import { StringRecordId } from "surrealdb";
+import type { Surreal } from "surrealdb";
+import { paginate, gh } from "../clients/github.ts";
+import { isBot } from "./bot.ts";
+import { upsertUser } from "./user.ts";
+import { upsertLabelsAndEdges } from "./labels.ts";
+import type { ParsedUser, ParsedLabel, RepoRef } from "./types.ts";
+
+export type ParsedIssue = {
+  github_node_id: string;
+  github_url: string;
+  number: number;
+  title: string;
+  body: string;
+  state: "OPEN" | "CLOSED";
+  state_reason: string | null;
+  closed_at: Date | null;
+  created_at: Date;
+  updated_at: Date;
+  content_hash: string;
+  author: ParsedUser | null;
+  labels: ParsedLabel[];
+};
+
+const LabelNodeSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  color: z.string(),
+  description: z.string().nullable(),
+});
+
+const LabelConnectionSchema = z.object({
+  nodes: z.array(LabelNodeSchema),
+  pageInfo: z.object({
+    hasNextPage: z.boolean(),
+    endCursor: z.string().nullable(),
+  }),
+});
+
+const AuthorSchema = z
+  .object({
+    __typename: z.string(),
+    id: z.string().optional(),
+    login: z.string(),
+    url: z.string(),
+  })
+  .nullable();
+
+const IssueNodeSchema = z.object({
+  id: z.string(),
+  url: z.string(),
+  number: z.number(),
+  title: z.string(),
+  body: z.string().nullable(),
+  state: z.enum(["OPEN", "CLOSED"]),
+  stateReason: z.string().nullable(),
+  closedAt: z.string().nullable(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+  author: AuthorSchema,
+  labels: LabelConnectionSchema,
+});
+
+const ISSUES_QUERY = `
+  query FetchIssues($owner: String!, $name: String!, $cursor: String) {
+    repository(owner: $owner, name: $name) {
+      issues(first: 100, after: $cursor, orderBy: {field: UPDATED_AT, direction: ASC}) {
+        pageInfo { hasNextPage endCursor }
+        nodes {
+          id url number title body state stateReason closedAt createdAt updatedAt
+          author {
+            __typename
+            login
+            url
+            ... on User { id }
+            ... on Bot { id }
+          }
+          labels(first: 50) {
+            nodes { id name color description }
+            pageInfo { hasNextPage endCursor }
+          }
+        }
+      }
+    }
+  }
+`;
+
+const LABELS_QUERY = `
+  query FetchIssueLabels($owner: String!, $name: String!, $number: Int!, $cursor: String) {
+    repository(owner: $owner, name: $name) {
+      issue(number: $number) {
+        labels(first: 50, after: $cursor) {
+          nodes { id name color description }
+          pageInfo { hasNextPage endCursor }
+        }
+      }
+    }
+  }
+`;
+
+export function computeContentHash(title: string, rawBody: string | null): string {
+  const normalizedBody = (rawBody ?? "").replace(/\r\n/g, "\n");
+  return createHash("sha256")
+    .update(`${title}\n\n${normalizedBody}`)
+    .digest("hex");
+}
+
+export async function* fetchIssues(owner: string, name: string): AsyncGenerator<ParsedIssue> {
+  for await (const rawNode of paginate(
+    ISSUES_QUERY,
+    { owner, name },
+    (data: unknown) => {
+      const d = data as {
+        repository: {
+          issues: {
+            nodes: unknown[];
+            pageInfo: { hasNextPage: boolean; endCursor: string | null };
+          };
+        };
+      };
+      return d.repository.issues;
+    },
+  )) {
+    const node = IssueNodeSchema.parse(rawNode);
+
+    let author: ParsedUser | null = null;
+    if (node.author !== null) {
+      const { __typename, id, login, url: github_url } = node.author;
+      if ((__typename === "User" || __typename === "Bot") && id !== undefined) {
+        author = {
+          github_node_id: id,
+          login,
+          is_bot: isBot(__typename, login),
+          github_url,
+        };
+      }
+    }
+
+    let labelNodes = node.labels.nodes;
+    let labelPageInfo = node.labels.pageInfo;
+
+    while (labelPageInfo.hasNextPage) {
+      const moreData = await gh<unknown>(LABELS_QUERY, {
+        owner,
+        name,
+        number: node.number,
+        cursor: labelPageInfo.endCursor,
+      });
+      const moreConn = (
+        moreData as { repository: { issue: { labels: unknown } } }
+      ).repository.issue.labels;
+      const moreParsed = LabelConnectionSchema.parse(moreConn);
+      labelNodes = [...labelNodes, ...moreParsed.nodes];
+      labelPageInfo = moreParsed.pageInfo;
+    }
+
+    const labels: ParsedLabel[] = labelNodes.map((l) => ({
+      github_node_id: l.id,
+      name: l.name,
+      color: l.color,
+      description: l.description,
+    }));
+
+    const content_hash = computeContentHash(node.title, node.body);
+
+    yield {
+      github_node_id: node.id,
+      github_url: node.url,
+      number: node.number,
+      title: node.title,
+      body: (node.body ?? "").replace(/\r\n/g, "\n"),
+      state: node.state,
+      state_reason: node.stateReason,
+      closed_at: node.closedAt ? new Date(node.closedAt) : null,
+      created_at: new Date(node.createdAt),
+      updated_at: new Date(node.updatedAt),
+      content_hash,
+      author,
+      labels,
+    };
+  }
+}
+
+export async function persistIssue(
+  db: Surreal,
+  repo: RepoRef,
+  parsed: ParsedIssue,
+): Promise<void> {
+  const repoRef = new StringRecordId(repo.id);
+
+  let authorRef: StringRecordId | undefined;
+  if (parsed.author !== null) {
+    const id = await upsertUser(db, parsed.author);
+    authorRef = new StringRecordId(id);
+  }
+
+  const authorSql = parsed.author !== null ? "$author" : "NONE";
+  const stateReasonSql = parsed.state_reason !== null ? "$state_reason" : "NONE";
+  const closedAtSql = parsed.closed_at !== null ? "$closed_at" : "NONE";
+
+  const [existing] = await db.query<[Array<{ id: unknown }>]>(
+    "SELECT id FROM issue WHERE github_node_id = $github_node_id",
+    { github_node_id: parsed.github_node_id },
+  );
+
+  let issueRecordId: string;
+
+  if (existing.length === 0) {
+    const [created] = await db.query<[Array<{ id: unknown }>]>(
+      `CREATE issue CONTENT {
+        github_node_id: $github_node_id,
+        github_url: $github_url,
+        repo: $repo,
+        number: $number,
+        title: $title,
+        body: $body,
+        state: $state,
+        state_reason: ${stateReasonSql},
+        author: ${authorSql},
+        closed_at: ${closedAtSql},
+        created_at: $created_at,
+        updated_at: $updated_at,
+        deleted_at: NONE,
+        content_hash: $content_hash,
+        embedding: NONE
+      }`,
+      {
+        github_node_id: parsed.github_node_id,
+        github_url: parsed.github_url,
+        repo: repoRef,
+        number: parsed.number,
+        title: parsed.title,
+        body: parsed.body,
+        state: parsed.state,
+        ...(parsed.state_reason !== null ? { state_reason: parsed.state_reason } : {}),
+        ...(parsed.author !== null ? { author: authorRef } : {}),
+        ...(parsed.closed_at !== null ? { closed_at: parsed.closed_at } : {}),
+        created_at: parsed.created_at,
+        updated_at: parsed.updated_at,
+        content_hash: parsed.content_hash,
+      },
+    );
+    issueRecordId = String(created[0].id);
+  } else {
+    issueRecordId = String(existing[0].id);
+    await db.query(
+      `UPDATE $id SET
+        github_url = $github_url,
+        title = $title,
+        body = $body,
+        state = $state,
+        state_reason = ${stateReasonSql},
+        author = ${authorSql},
+        closed_at = ${closedAtSql},
+        updated_at = $updated_at,
+        content_hash = $content_hash`,
+      {
+        id: new StringRecordId(issueRecordId),
+        github_url: parsed.github_url,
+        title: parsed.title,
+        body: parsed.body,
+        state: parsed.state,
+        ...(parsed.state_reason !== null ? { state_reason: parsed.state_reason } : {}),
+        ...(parsed.author !== null ? { author: authorRef } : {}),
+        ...(parsed.closed_at !== null ? { closed_at: parsed.closed_at } : {}),
+        updated_at: parsed.updated_at,
+        content_hash: parsed.content_hash,
+      },
+    );
+  }
+
+  await upsertLabelsAndEdges(db, issueRecordId, parsed.labels);
+}

--- a/src/ingest/labels.test.ts
+++ b/src/ingest/labels.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from "bun:test";
+import { withTestDb } from "../test_utils/with_test_db.ts";
+import { upsertLabelsAndEdges } from "./labels.ts";
+import type { ParsedLabel } from "./types.ts";
+
+const labels: ParsedLabel[] = [
+  { github_node_id: "LB_1", name: "bug", color: "d73a4a", description: "Something broken" },
+  { github_node_id: "LB_2", name: "enhancement", color: "a2eeef", description: null },
+];
+
+describe("upsertLabelsAndEdges", () => {
+  it("creates 2 labels and 2 edges, no duplicates on second call", async () => {
+    await withTestDb(async (db) => {
+      const [orgRows] = await db.query<[Array<{ id: unknown }>]>(
+        `CREATE org CONTENT {
+          github_node_id: "ORG_1",
+          github_url: "https://github.com/test",
+          login: "test",
+          name: "Test",
+          kind: "User",
+          created_at: time::now(),
+          updated_at: time::now(),
+          deleted_at: NONE
+        }`,
+      );
+      const orgId = orgRows[0].id;
+
+      const [repoRows] = await db.query<[Array<{ id: unknown }>]>(
+        `CREATE repo CONTENT {
+          github_node_id: "REPO_1",
+          github_url: "https://github.com/test/repo",
+          name: "repo",
+          name_with_owner: "test/repo",
+          description: NONE,
+          is_private: false,
+          owner: $orgId,
+          created_at: time::now(),
+          updated_at: time::now(),
+          deleted_at: NONE
+        }`,
+        { orgId },
+      );
+      const repoId = repoRows[0].id;
+
+      const [issueRows] = await db.query<[Array<{ id: unknown }>]>(
+        `CREATE issue CONTENT {
+          github_node_id: "ISSUE_1",
+          github_url: "https://github.com/test/repo/issues/1",
+          repo: $repoId,
+          number: 1,
+          title: "Test issue",
+          body: NONE,
+          state: "OPEN",
+          state_reason: NONE,
+          author: NONE,
+          closed_at: NONE,
+          created_at: time::now(),
+          updated_at: time::now(),
+          deleted_at: NONE,
+          content_hash: NONE,
+          embedding: NONE
+        }`,
+        { repoId },
+      );
+      const issueId = String(issueRows[0].id);
+
+      await upsertLabelsAndEdges(db, issueId, labels);
+
+      const [labelRows1] = await db.query<[Array<unknown>]>("SELECT id FROM label");
+      const [edgeRows1] = await db.query<[Array<unknown>]>("SELECT id FROM has_label");
+      expect(labelRows1.length).toBe(2);
+      expect(edgeRows1.length).toBe(2);
+
+      await upsertLabelsAndEdges(db, issueId, labels);
+
+      const [labelRows2] = await db.query<[Array<unknown>]>("SELECT id FROM label");
+      const [edgeRows2] = await db.query<[Array<unknown>]>("SELECT id FROM has_label");
+      expect(labelRows2.length).toBe(2);
+      expect(edgeRows2.length).toBe(2);
+    });
+  });
+});

--- a/src/ingest/labels.ts
+++ b/src/ingest/labels.ts
@@ -1,0 +1,82 @@
+import { StringRecordId } from "surrealdb";
+import type { Surreal } from "surrealdb";
+import type { ParsedLabel } from "./types.ts";
+
+// STUB: refined by #6. Stable signature.
+export async function upsertLabelsAndEdges(
+  db: Surreal,
+  parentRecordId: string,
+  labels: ParsedLabel[],
+): Promise<void> {
+  const parentRef = new StringRecordId(parentRecordId);
+
+  const [parentRows] = await db.query<[Array<{ repo: unknown }>]>(
+    "SELECT repo FROM $parentRef",
+    { parentRef },
+  );
+
+  const repoId = parentRows[0]?.repo;
+
+  for (const label of labels) {
+    const [existing] = await db.query<[Array<{ id: unknown }>]>(
+      "SELECT id FROM label WHERE github_node_id = $github_node_id",
+      { github_node_id: label.github_node_id },
+    );
+
+    // SurrealDB option<string> accepts strings or NONE, not JS null.
+    // Inline NONE as a SQL literal when description is null.
+    const descSql = label.description === null ? "NONE" : "$description";
+    const descParam = label.description !== null ? { description: label.description } : {};
+
+    let labelId: unknown;
+    if (existing.length === 0) {
+      const [created] = await db.query<[Array<{ id: unknown }>]>(
+        `CREATE label CONTENT {
+          github_node_id: $github_node_id,
+          repo: $repo,
+          name: $name,
+          color: $color,
+          description: ${descSql},
+          created_at: time::now(),
+          updated_at: time::now(),
+          deleted_at: NONE
+        }`,
+        {
+          github_node_id: label.github_node_id,
+          repo: repoId,
+          name: label.name,
+          color: label.color,
+          ...descParam,
+        },
+      );
+      labelId = created[0].id;
+    } else {
+      labelId = existing[0].id;
+      await db.query(
+        `UPDATE $id SET
+          name = $name,
+          color = $color,
+          description = ${descSql},
+          updated_at = time::now()`,
+        {
+          id: labelId,
+          name: label.name,
+          color: label.color,
+          ...descParam,
+        },
+      );
+    }
+
+    const [edges] = await db.query<[Array<{ id: unknown }>]>(
+      "SELECT id FROM has_label WHERE in = $parentRef AND out = $labelId",
+      { parentRef, labelId },
+    );
+
+    if (edges.length === 0) {
+      await db.query(
+        "RELATE $parentRef->has_label->$labelId CONTENT { created_at: time::now() }",
+        { parentRef, labelId },
+      );
+    }
+  }
+}

--- a/src/ingest/types.ts
+++ b/src/ingest/types.ts
@@ -1,0 +1,18 @@
+export type RepoRef = {
+  id: string;
+  name_with_owner: string;
+};
+
+export type ParsedUser = {
+  github_node_id: string;
+  login: string;
+  is_bot: boolean;
+  github_url: string;
+};
+
+export type ParsedLabel = {
+  github_node_id: string;
+  name: string;
+  color: string;
+  description: string | null;
+};

--- a/src/ingest/user.test.ts
+++ b/src/ingest/user.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "bun:test";
+import { withTestDb } from "../test_utils/with_test_db.ts";
+import { upsertUser } from "./user.ts";
+import type { ParsedUser } from "./types.ts";
+
+const testUser: ParsedUser = {
+  github_node_id: "U_1234",
+  login: "testuser",
+  is_bot: false,
+  github_url: "https://github.com/testuser",
+};
+
+describe("upsertUser", () => {
+  it("returns same id on second call and leaves exactly 1 row", async () => {
+    await withTestDb(async (db) => {
+      const id1 = await upsertUser(db, testUser);
+      const id2 = await upsertUser(db, testUser);
+
+      expect(id1).toBe(id2);
+
+      const [rows] = await db.query<[Array<unknown>]>(
+        "SELECT id FROM user WHERE github_node_id = $n",
+        { n: testUser.github_node_id },
+      );
+      expect(rows.length).toBe(1);
+    });
+  });
+});

--- a/src/ingest/user.ts
+++ b/src/ingest/user.ts
@@ -1,0 +1,47 @@
+import type { Surreal } from "surrealdb";
+import type { ParsedUser } from "./types.ts";
+
+export async function upsertUser(db: Surreal, parsed: ParsedUser): Promise<string> {
+  const [existing] = await db.query<[Array<{ id: unknown }>]>(
+    "SELECT id FROM user WHERE github_node_id = $github_node_id",
+    { github_node_id: parsed.github_node_id },
+  );
+
+  if (existing.length > 0) {
+    await db.query(
+      `UPDATE $id SET
+        login = $login,
+        is_bot = $is_bot,
+        github_url = $github_url,
+        updated_at = time::now()`,
+      {
+        id: existing[0].id,
+        login: parsed.login,
+        is_bot: parsed.is_bot,
+        github_url: parsed.github_url,
+      },
+    );
+    return String(existing[0].id);
+  }
+
+  const [created] = await db.query<[Array<{ id: unknown }>]>(
+    `CREATE user CONTENT {
+      github_node_id: $github_node_id,
+      github_url: $github_url,
+      login: $login,
+      name: NONE,
+      is_bot: $is_bot,
+      created_at: time::now(),
+      updated_at: time::now(),
+      deleted_at: NONE
+    }`,
+    {
+      github_node_id: parsed.github_node_id,
+      github_url: parsed.github_url,
+      login: parsed.login,
+      is_bot: parsed.is_bot,
+    },
+  );
+
+  return String(created[0].id);
+}


### PR DESCRIPTION
## Summary

First ingest pipeline: a pure async-generator `fetchIssues(owner, name)` and a DB-only `persistIssue(db, repo, parsed)` for GitHub issues, plus the cross-cutting helpers (`upsertUser`, `isBot`, `upsertLabelsAndEdges`) that #4 / #5 / #7 will reuse.

This PR sets the precedent for the rest of the ingest issues:
- One file per entity at `src/ingest/<entity>.ts`.
- Stage purity enforced by signatures (`fetch*` is DB-agnostic; `persist*` is pure infrastructure).
- Cross-cutting helpers in their own modules with stable signatures (#6 owns `upsertLabelsAndEdges` final, #9 owns `isBot`, #3 owns `upsertUser`).
- Fixtures live at `src/ingest/__fixtures__/<entity>_page_<n>.json`.

## What's in scope

- `src/ingest/issue.ts` — fetcher (with secondary per-issue label pagination) + persister + exported `computeContentHash` (canonical SHA-256 helper #11 will reuse for embed-skip).
- `src/ingest/user.ts` — `upsertUser(db, parsed) → Promise<string>` returning the SurrealDB record id.
- `src/ingest/bot.ts` — stub `isBot(typename, login)` (#9 owns the canonical implementation).
- `src/ingest/labels.ts` — stub `upsertLabelsAndEdges(db, parent, labels)` (#6 owns refinement: catalog fetch, replace-all semantics).
- `src/ingest/types.ts` — shared `RepoRef`, `ParsedUser`, `ParsedLabel`.
- 7 test files covering: content-hash determinism, persist idempotency, null-author path, multi-page fetch via `mock.module`, user upsert idempotency, label edge dedup, bot detection truth table.

## Architectural notes

- Per the schema (`schemas.surrealql`), repo→issue containment is expressed via the `issue.repo: record<repo>` link, **not** a separate `has` edge table. The persister uses the record link consistently. (The issue spec mentioned `has` but the schema authors went with the link; we follow the schema.)
- Author normalization: `author` is set to `null` when GraphQL returns `null` OR when `__typename` is not `User` / `Bot` (e.g., `Mannequin`, `Organization`, `EnterpriseUserAccount`). Schema field is `option<record<user>>`.
- Per-issue label pagination is implemented as a secondary query when `labels.pageInfo.hasNextPage` — an issue with > 50 labels is rare but the fetcher is honest about completeness.

## Test plan

- [x] `bun run typecheck` — clean.
- [x] `bun test` — 33/33 pass across 9 files.
- [x] Fetch test exercises 2-page fixture (page 1 hasNextPage=true → page 2 hasNextPage=false), validates content-hash determinism, null-author handling, bot author flagging, CRLF→LF normalization.
- [x] Persist test verifies idempotency (no duplicate users / labels / edges) and the null-author path.
- [ ] `bun run smoke:*` (manual; unaffected by this PR).

## Out of scope

- Comments (#7), cross-references in body (#8), bot heuristic refinement (#9), label catalog + replace-all (#6), embedding (#11), incremental sync (#14), `tool sync` wiring (#10).

Closes #3


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the GitHub issues ingest pipeline with an async `fetchIssues(owner, name)` and a DB-only `persistIssue(db, repo, parsed)`, plus shared helpers for users, labels, and bot detection. Ensures complete label coverage and idempotent writes.

- **New Features**
  - Issue fetcher: paginates issues and per-issue labels, normalizes CRLF to LF, and computes a SHA-256 `content_hash`.
  - Issue persister: uses a repo record link, normalizes non-user authors to `null`, and upserts without duplicates (including label edges).
  - Shared helpers: `upsertUser(db, parsed) → Promise<string>`, `isBot(typename, login)`, and `upsertLabelsAndEdges(db, parentRecordId, labels)` for reuse across ingest stages.

<sup>Written for commit 0a9d325d1de70fd3c49a42c513aea9e294ef9abb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

