### PR TITLE
docs: capture review learnings (SurrealDB WASM, paginate)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,6 +72,36 @@ Smoke tests (`bun run smoke:*`) are **manual** — they require live SurrealDB, 
 - **`references` is a reserved word in SurrealQL** — the cross-reference edge table is `references_ref` for that reason. Don't rename it back.
 - **GraphQL author union is mandatory**: every author site must use `... on User { ... } ... on Bot { ... }` so `__typename` is available for `isBot()` (per the bot detection principle).
 - **`embedded_content_hash` vs `content_hash`**: `content_hash` is computed on persist; `embedded_content_hash` is set on embed. The trigger to re-embed is `content_hash != embedded_content_hash`. Don't conflate them.
+- **The `paginate` helper injects a variable named `cursor`.** Every paginated GraphQL query MUST declare `$cursor: String` and use it in the `after:` argument. Variable name mismatch is silent — GraphQL ignores undeclared vars and starts every page from the first.
+
+### SurrealDB v2 + WASM (in-memory mode) gotchas
+
+The in-memory engine used by `withTestDb` is `@surrealdb/wasm`. It diverges from the documented patterns in subtle ways. Check these before assuming an API works:
+
+- **`mem://` requires `namespace` and `database`** in `connect()` opts, even though no auth is needed. Skipping them throws `Specify a namespace to use`.
+- **`engines` belong in the `Surreal` constructor (`DriverOptions`), NOT in `ConnectOptions`.** The right shape is `new Surreal({ engines: { ...createRemoteEngines(), ...createWasmEngines() } })`. Putting engines in `connect()` silently does nothing.
+- **`type::thing(table, id)` is unsupported in WASM.** Use `new StringRecordId("table:id")` from the `surrealdb` package and pass it as a query param. Round-trip: `String(row.id)` → `new StringRecordId(...)` to reuse a record id.
+- **`option<string>` fields reject JS `null`** at the SurrealQL boundary. To set a nullable field to none, inline the literal `NONE` in the query string and conditionally spread the param object — don't bind `null` to a `$param`. Pattern:
+  ```ts
+  const fieldSql = parsed.field !== null ? "$field" : "NONE";
+  await db.query(`UPDATE $id SET field = ${fieldSql}`, {
+    id, ...(parsed.field !== null ? { field: parsed.field } : {})
+  });
+  ```
+  An issue is filed to extract this into a helper once a few more sites use it.
+
+When in doubt about a SurrealDB API shape, read the type definitions directly:
+```bash
+grep -E "^\s*(connect|query|close)" node_modules/surrealdb/dist/surrealdb.d.ts
+```
+
+## Notes for harny prompts
+
+When writing prompts for harny dispatch (or any subagent doing implementation):
+
+- **Code review for try/catch scope**: validators check that error commands exit 1, but they don't catch a `try` that's wrapped too widely. When a prompt asks for try/catch, also instruct: "write a test that throws inside the protected region (e.g., make the inner function throw on purpose) and verify the real error surfaces, not the catch's fallback message."
+- **Verify SDK shapes before asserting them in the prompt.** Past harny runs caught two factual errors in architect prompts about the SurrealDB API. Before specifying "the call signature is X," run `Read node_modules/<pkg>/dist/<pkg>.d.ts` (or grep for the symbol) to confirm.
+- **Don't pre-decompose tasks the planner could merge.** A 2-task split where t2 strictly depends on t1 buys no parallelism and adds two extra phase transitions. Let the planner own the split.
 
 ## Git / PR
 

--- a/src/clients/github.ts
+++ b/src/clients/github.ts
@@ -16,6 +16,25 @@ export function gh<T>(query: string, params?: RequestParameters): Promise<T> {
   return getGh()<T>(query, params);
 }
 
+/**
+ * Walks a paginated GraphQL connection, yielding nodes one at a time.
+ *
+ * The cursor is injected into `variables` under the key `cursor` —
+ * your query MUST declare `$cursor: String` and reference it via
+ * the connection's `after:` argument. Mismatched variable names are
+ * silent in GraphQL: undeclared vars are ignored and the connection
+ * restarts from the first page on every iteration, producing an
+ * infinite loop.
+ *
+ * Example:
+ * ```graphql
+ * query($owner: String!, $name: String!, $cursor: String) {
+ *   repository(owner: $owner, name: $name) {
+ *     issues(first: 100, after: $cursor) { ... }
+ *   }
+ * }
+ * ```
+ */
 export async function* paginate<T>(
   query: string,
   variables: Record<string, unknown>,


### PR DESCRIPTION
Captures three findings from the post-mortem review of harny runs #1–#3:

1. **CLAUDE.md → Gotchas section**: explicit note that the `paginate` helper injects a variable named `cursor` (the original implementation in #1 used `after` and the mismatch was only caught in architect code review).
2. **CLAUDE.md → new section "SurrealDB v2 + WASM gotchas"**: documents the 4 issues that cost debug time across runs #13 and #3 — `mem://` namespace requirement, engines-in-constructor (not connect opts), `type::thing()` unsupported in WASM, `option<string>` rejecting JS `null`. Each has a fix or workaround inline.
3. **CLAUDE.md → "Notes for harny prompts"**: practical guidance for future prompt writers — verify SDK shapes before asserting them in prompts; instruct validators to test try/catch scope; don't pre-decompose tasks the planner could merge.
4. **`src/clients/github.ts`**: JSDoc on `paginate` making the cursor variable contract explicit (no behavior change).

Filed as a follow-up: lfnovo/repo-embed#22 (extract NONE-handling helper) — captured the recurring pattern across add.ts / issue.ts / labels.ts but defer the refactor until #4 / #5 / #7 land so the cleanup hits all sites in one focused PR.

## Test plan
- [x] `bun run typecheck` clean.
- [x] `bun test` 33/33 pass.
- [x] No behavior change (docs + JSDoc only).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies the `paginate` GraphQL helper by documenting its `$cursor` requirement (with JSDoc in `src/clients/github.ts`) and expands `CLAUDE.md` with SurrealDB v2 + `@surrealdb/wasm` gotchas and prompt-writing notes. No behavior change.

<sup>Written for commit 1eff20d1dc703d1f9cc62da7a212176e9f7919ec. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

