### PR TITLE
feat: discussion fetcher + persister with hasDiscussionsEnabled probe

### DIFF
--- a/src/ingest/__fixtures__/discussions_disabled.json
+++ b/src/ingest/__fixtures__/discussions_disabled.json
@@ -1,0 +1,1 @@
+{ "repository": { "hasDiscussionsEnabled": false } }

--- a/src/ingest/__fixtures__/discussions_page_1.json
+++ b/src/ingest/__fixtures__/discussions_page_1.json
@@ -1,0 +1,65 @@
+{
+  "repository": {
+    "discussions": {
+      "nodes": [
+        {
+          "id": "D_001",
+          "url": "https://github.com/test/repo/discussions/1",
+          "number": 1,
+          "title": "How to configure this?",
+          "body": "I need help with configuration\r\ncan you help?",
+          "closedAt": null,
+          "createdAt": "2026-01-01T00:00:00Z",
+          "updatedAt": "2026-01-02T00:00:00Z",
+          "author": {
+            "__typename": "User",
+            "id": "U_001",
+            "login": "testuser",
+            "url": "https://github.com/testuser"
+          },
+          "category": {
+            "name": "Q&A",
+            "emoji": ":question:",
+            "isAnswerable": true
+          },
+          "answer": { "id": "DC_001" },
+          "answerChosenAt": "2026-01-03T00:00:00Z",
+          "labels": {
+            "nodes": [
+              {
+                "id": "LB_001",
+                "name": "question",
+                "color": "d876e3",
+                "description": "Further information is requested"
+              }
+            ],
+            "pageInfo": { "hasNextPage": false, "endCursor": null }
+          }
+        },
+        {
+          "id": "D_002",
+          "url": "https://github.com/test/repo/discussions/2",
+          "number": 2,
+          "title": "General feedback",
+          "body": null,
+          "closedAt": null,
+          "createdAt": "2026-01-02T00:00:00Z",
+          "updatedAt": "2026-01-03T00:00:00Z",
+          "author": null,
+          "category": {
+            "name": "General",
+            "emoji": ":speech_balloon:",
+            "isAnswerable": false
+          },
+          "answer": null,
+          "answerChosenAt": null,
+          "labels": {
+            "nodes": [],
+            "pageInfo": { "hasNextPage": false, "endCursor": null }
+          }
+        }
+      ],
+      "pageInfo": { "hasNextPage": true, "endCursor": "cursor1" }
+    }
+  }
+}

--- a/src/ingest/__fixtures__/discussions_page_2.json
+++ b/src/ingest/__fixtures__/discussions_page_2.json
@@ -1,0 +1,36 @@
+{
+  "repository": {
+    "discussions": {
+      "nodes": [
+        {
+          "id": "D_003",
+          "url": "https://github.com/test/repo/discussions/3",
+          "number": 3,
+          "title": "Dependency update available",
+          "body": "A new version of a dependency is available",
+          "closedAt": null,
+          "createdAt": "2026-01-04T00:00:00Z",
+          "updatedAt": "2026-01-05T00:00:00Z",
+          "author": {
+            "__typename": "Bot",
+            "id": "B_001",
+            "login": "dependabot[bot]",
+            "url": "https://github.com/apps/dependabot"
+          },
+          "category": {
+            "name": "General",
+            "emoji": ":speech_balloon:",
+            "isAnswerable": false
+          },
+          "answer": null,
+          "answerChosenAt": null,
+          "labels": {
+            "nodes": [],
+            "pageInfo": { "hasNextPage": false, "endCursor": null }
+          }
+        }
+      ],
+      "pageInfo": { "hasNextPage": false, "endCursor": null }
+    }
+  }
+}

--- a/src/ingest/discussion.test.ts
+++ b/src/ingest/discussion.test.ts
@@ -1,0 +1,353 @@
+import { describe, it, expect, mock } from "bun:test";
+import { withTestDb } from "../test_utils/with_test_db.ts";
+
+import page1 from "./__fixtures__/discussions_page_1.json";
+import page2 from "./__fixtures__/discussions_page_2.json";
+
+let ghProbeResult: unknown = { repository: { hasDiscussionsEnabled: true } };
+
+mock.module("../clients/github.ts", () => ({
+  paginate: async function* (
+    _query: string,
+    _variables: unknown,
+    selectConnection: (data: unknown) => {
+      nodes: unknown[];
+      pageInfo: { hasNextPage: boolean; endCursor: string | null };
+    },
+  ) {
+    for (const page of [page1, page2]) {
+      const connection = selectConnection(page);
+      for (const node of connection.nodes) {
+        yield node;
+      }
+    }
+  },
+  gh: async () => ghProbeResult,
+}));
+
+const { fetchDiscussions, persistDiscussion, computeContentHash, resolveDiscussionAnswerLinks } =
+  await import("./discussion.ts");
+type ParsedDiscussion = Parameters<typeof persistDiscussion>[2];
+
+// ─── shared repo setup ────────────────────────────────────────────────────────
+
+async function setupRepo(
+  db: Parameters<Parameters<typeof withTestDb>[0]>[0],
+  suffix: string,
+): Promise<string> {
+  const [orgRows] = await db.query<[Array<{ id: unknown }>]>(
+    `CREATE org CONTENT {
+      github_node_id: $nid,
+      github_url: $url,
+      login: $login,
+      name: $name,
+      kind: "User",
+      created_at: time::now(),
+      updated_at: time::now(),
+      deleted_at: NONE
+    }`,
+    {
+      nid: `ORG_${suffix}`,
+      url: `https://github.com/testorg${suffix}`,
+      login: `testorg${suffix}`,
+      name: `Test Org ${suffix}`,
+    },
+  );
+  const orgId = orgRows[0].id;
+
+  const [repoRows] = await db.query<[Array<{ id: unknown }>]>(
+    `CREATE repo CONTENT {
+      github_node_id: $nid,
+      github_url: $url,
+      name: "repo",
+      name_with_owner: $nwo,
+      description: NONE,
+      is_private: false,
+      owner: $orgId,
+      created_at: time::now(),
+      updated_at: time::now(),
+      deleted_at: NONE
+    }`,
+    {
+      nid: `REPO_${suffix}`,
+      url: `https://github.com/testorg${suffix}/repo`,
+      nwo: `testorg${suffix}/repo`,
+      orgId,
+    },
+  );
+  return String(repoRows[0].id);
+}
+
+// ─── 1. computeContentHash ────────────────────────────────────────────────────
+
+describe("computeContentHash", () => {
+  it("same (title, body) always produces the same hex string", () => {
+    const h1 = computeContentHash("My Title", "Some body");
+    const h2 = computeContentHash("My Title", "Some body");
+    expect(h1).toBe(h2);
+    expect(h1).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("CRLF and LF bodies produce the same hash", () => {
+    const crlfHash = computeContentHash("T", "Hello\r\nWorld");
+    const lfHash = computeContentHash("T", "Hello\nWorld");
+    expect(crlfHash).toBe(lfHash);
+  });
+
+  it("different inputs produce different hashes", () => {
+    const h1 = computeContentHash("Title A", "body");
+    const h2 = computeContentHash("Title B", "body");
+    expect(h1).not.toBe(h2);
+  });
+
+  it("null body is treated as empty string", () => {
+    const h1 = computeContentHash("T", null);
+    const h2 = computeContentHash("T", "");
+    expect(h1).toBe(h2);
+  });
+});
+
+// ─── 2. persistDiscussion idempotency ─────────────────────────────────────────
+
+describe("persistDiscussion idempotency", () => {
+  it("persist same discussion twice leaves exactly 1 discussion, 1 user, and 1 has_label edge", async () => {
+    await withTestDb(async (db) => {
+      const repoId = await setupRepo(db, "DA");
+      const repo = { id: repoId, name_with_owner: "testorgDA/repo" };
+
+      const parsed: ParsedDiscussion = {
+        github_node_id: "D_IDEM_1",
+        github_url: "https://github.com/testorgDA/repo/discussions/10",
+        number: 10,
+        title: "Idempotency Test Discussion",
+        body: "Some body text",
+        closed_at: null,
+        created_at: new Date("2026-01-01T00:00:00Z"),
+        updated_at: new Date("2026-01-02T00:00:00Z"),
+        content_hash: computeContentHash("Idempotency Test Discussion", "Some body text"),
+        category_name: "Q&A",
+        answer_chosen_at: new Date("2026-01-03T00:00:00Z"),
+        author: {
+          github_node_id: "U_IDEM_D1",
+          login: "testuser",
+          is_bot: false,
+          github_url: "https://github.com/testuser",
+        },
+        labels: [
+          { github_node_id: "LB_IDEM_D1", name: "bug", color: "d73a4a", description: "A bug" },
+        ],
+      };
+
+      await persistDiscussion(db, repo, parsed);
+      await persistDiscussion(db, repo, parsed);
+
+      const [discRows] = await db.query<[Array<unknown>]>("SELECT id FROM discussion");
+      expect(discRows.length).toBe(1);
+
+      const [userRows] = await db.query<[Array<unknown>]>("SELECT id FROM user");
+      expect(userRows.length).toBe(1);
+
+      const [edgeRows] = await db.query<[Array<unknown>]>("SELECT id FROM has_label");
+      expect(edgeRows.length).toBe(1);
+    });
+  });
+});
+
+// ─── 3. author: null path ─────────────────────────────────────────────────────
+
+describe("persistDiscussion author: null", () => {
+  it("stores author as NONE and creates no user rows", async () => {
+    await withTestDb(async (db) => {
+      const repoId = await setupRepo(db, "DB");
+      const repo = { id: repoId, name_with_owner: "testorgDB/repo" };
+
+      const parsed: ParsedDiscussion = {
+        github_node_id: "D_NULL_AUTH",
+        github_url: "https://github.com/testorgDB/repo/discussions/5",
+        number: 5,
+        title: "No Author Discussion",
+        body: "",
+        closed_at: null,
+        created_at: new Date("2026-01-01T00:00:00Z"),
+        updated_at: new Date("2026-01-10T00:00:00Z"),
+        content_hash: computeContentHash("No Author Discussion", ""),
+        category_name: "General",
+        answer_chosen_at: null,
+        author: null,
+        labels: [],
+      };
+
+      await persistDiscussion(db, repo, parsed);
+
+      const [isNoneRows] = await db.query<[Array<{ is_none: boolean }>]>(
+        "SELECT author IS NONE AS is_none FROM discussion WHERE github_node_id = $id",
+        { id: "D_NULL_AUTH" },
+      );
+      expect(isNoneRows.length).toBe(1);
+      expect(isNoneRows[0].is_none).toBe(true);
+
+      const [userRows] = await db.query<[Array<unknown>]>("SELECT id FROM user");
+      expect(userRows.length).toBe(0);
+    });
+  });
+});
+
+// ─── 4. category capture ──────────────────────────────────────────────────────
+
+describe("persistDiscussion category capture", () => {
+  it("stores category_name as the category field in the DB", async () => {
+    await withTestDb(async (db) => {
+      const repoId = await setupRepo(db, "DC");
+      const repo = { id: repoId, name_with_owner: "testorgDC/repo" };
+
+      const parsed: ParsedDiscussion = {
+        github_node_id: "D_CAT_1",
+        github_url: "https://github.com/testorgDC/repo/discussions/7",
+        number: 7,
+        title: "Category Test",
+        body: "body",
+        closed_at: null,
+        created_at: new Date("2026-01-01T00:00:00Z"),
+        updated_at: new Date("2026-01-02T00:00:00Z"),
+        content_hash: computeContentHash("Category Test", "body"),
+        category_name: "Ideas",
+        answer_chosen_at: null,
+        author: null,
+        labels: [],
+      };
+
+      await persistDiscussion(db, repo, parsed);
+
+      const [rows] = await db.query<[Array<{ category: string }>]>(
+        "SELECT category FROM discussion WHERE github_node_id = $id",
+        { id: "D_CAT_1" },
+      );
+      expect(rows.length).toBe(1);
+      expect(rows[0].category).toBe("Ideas");
+    });
+  });
+});
+
+// ─── 5. answer_chosen_at ─────────────────────────────────────────────────────
+
+describe("persistDiscussion answer_chosen_at", () => {
+  it("stores non-null answer_chosen_at as a datetime, null as NONE", async () => {
+    await withTestDb(async (db) => {
+      const repoId = await setupRepo(db, "DD");
+      const repo = { id: repoId, name_with_owner: "testorgDD/repo" };
+
+      const withAnswer: ParsedDiscussion = {
+        github_node_id: "D_ANS_1",
+        github_url: "https://github.com/testorgDD/repo/discussions/8",
+        number: 8,
+        title: "Answered Discussion",
+        body: "body",
+        closed_at: null,
+        created_at: new Date("2026-01-01T00:00:00Z"),
+        updated_at: new Date("2026-01-02T00:00:00Z"),
+        content_hash: computeContentHash("Answered Discussion", "body"),
+        category_name: "Q&A",
+        answer_chosen_at: new Date("2026-01-05T00:00:00Z"),
+        author: null,
+        labels: [],
+      };
+
+      const withoutAnswer: ParsedDiscussion = {
+        github_node_id: "D_ANS_2",
+        github_url: "https://github.com/testorgDD/repo/discussions/9",
+        number: 9,
+        title: "Unanswered Discussion",
+        body: "body",
+        closed_at: null,
+        created_at: new Date("2026-01-01T00:00:00Z"),
+        updated_at: new Date("2026-01-02T00:00:00Z"),
+        content_hash: computeContentHash("Unanswered Discussion", "body"),
+        category_name: "Q&A",
+        answer_chosen_at: null,
+        author: null,
+        labels: [],
+      };
+
+      await persistDiscussion(db, repo, withAnswer);
+      await persistDiscussion(db, repo, withoutAnswer);
+
+      const [answeredRows] = await db.query<[Array<{ is_none: boolean }>]>(
+        "SELECT answer_chosen_at IS NONE AS is_none FROM discussion WHERE github_node_id = $id",
+        { id: "D_ANS_1" },
+      );
+      expect(answeredRows[0].is_none).toBe(false);
+
+      const [unansweredRows] = await db.query<[Array<{ is_none: boolean }>]>(
+        "SELECT answer_chosen_at IS NONE AS is_none FROM discussion WHERE github_node_id = $id",
+        { id: "D_ANS_2" },
+      );
+      expect(unansweredRows[0].is_none).toBe(true);
+    });
+  });
+});
+
+// ─── 6. fetchDiscussions end-to-end ───────────────────────────────────────────
+
+describe("fetchDiscussions mock", () => {
+  it("yields all discussions from both fixture pages with correct shape", async () => {
+    ghProbeResult = { repository: { hasDiscussionsEnabled: true } };
+
+    const discussions: ParsedDiscussion[] = [];
+    for await (const d of fetchDiscussions("test", "repo")) {
+      discussions.push(d);
+    }
+
+    expect(discussions.length).toBe(3);
+
+    const ids = discussions.map((d) => d.github_node_id);
+    expect(ids).toContain("D_001");
+    expect(ids).toContain("D_002");
+    expect(ids).toContain("D_003");
+
+    for (const d of discussions) {
+      expect(d.content_hash).toMatch(/^[0-9a-f]{64}$/);
+    }
+
+    const d1 = discussions.find((d) => d.github_node_id === "D_001")!;
+    expect(d1.answer_chosen_at).not.toBeNull();
+    expect(d1.category_name).toBe("Q&A");
+    expect(d1.author).not.toBeNull();
+    expect(d1.author?.login).toBe("testuser");
+    expect(d1.labels.length).toBe(1);
+
+    const d3 = discussions.find((d) => d.github_node_id === "D_003")!;
+    expect(d3.author).not.toBeNull();
+    expect(d3.author?.is_bot).toBe(true);
+  });
+});
+
+// ─── 7. fetchDiscussions hasDiscussionsEnabled=false ─────────────────────────
+
+describe("fetchDiscussions hasDiscussionsEnabled=false", () => {
+  it("yields zero items when discussions are disabled", async () => {
+    ghProbeResult = { repository: { hasDiscussionsEnabled: false } };
+
+    const discussions: ParsedDiscussion[] = [];
+    for await (const d of fetchDiscussions("test", "repo")) {
+      discussions.push(d);
+    }
+
+    expect(discussions.length).toBe(0);
+
+    // restore for subsequent tests
+    ghProbeResult = { repository: { hasDiscussionsEnabled: true } };
+  });
+});
+
+// ─── 8. resolveDiscussionAnswerLinks ─────────────────────────────────────────
+
+describe("resolveDiscussionAnswerLinks", () => {
+  it("returns { resolved: 0, pending: 0 } on empty DB", async () => {
+    await withTestDb(async (db) => {
+      const repoId = await setupRepo(db, "DE");
+      const repo = { id: repoId, name_with_owner: "testorgDE/repo" };
+      const result = await resolveDiscussionAnswerLinks(db, repo);
+      expect(result).toEqual({ resolved: 0, pending: 0 });
+    });
+  });
+});

--- a/src/ingest/discussion.ts
+++ b/src/ingest/discussion.ts
@@ -1,0 +1,308 @@
+import { createHash } from "node:crypto";
+import { z } from "zod";
+import { StringRecordId } from "surrealdb";
+import type { Surreal } from "surrealdb";
+import { paginate, gh } from "../clients/github.ts";
+import { isBot } from "./bot.ts";
+import { upsertUser } from "./user.ts";
+import { upsertLabelsAndEdges } from "./labels.ts";
+import type { ParsedUser, ParsedLabel, RepoRef } from "./types.ts";
+
+export type ParsedDiscussion = {
+  github_node_id: string;
+  github_url: string;
+  number: number;
+  title: string;
+  body: string;
+  created_at: Date;
+  updated_at: Date;
+  closed_at: Date | null;
+  content_hash: string;
+  category_name: string | null;
+  answer_chosen_at: Date | null;
+  author: ParsedUser | null;
+  labels: ParsedLabel[];
+};
+
+const LabelNodeSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  color: z.string(),
+  description: z.string().nullable(),
+});
+
+const LabelConnectionSchema = z.object({
+  nodes: z.array(LabelNodeSchema),
+  pageInfo: z.object({
+    hasNextPage: z.boolean(),
+    endCursor: z.string().nullable(),
+  }),
+});
+
+const AuthorSchema = z
+  .object({
+    __typename: z.string(),
+    id: z.string().optional(),
+    login: z.string(),
+    url: z.string(),
+  })
+  .nullable();
+
+const DiscussionNodeSchema = z.object({
+  id: z.string(),
+  url: z.string(),
+  number: z.number(),
+  title: z.string(),
+  body: z.string().nullable(),
+  closedAt: z.string().nullable(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+  author: AuthorSchema,
+  category: z
+    .object({
+      name: z.string(),
+      emoji: z.string(),
+      isAnswerable: z.boolean(),
+    })
+    .nullable(),
+  answer: z.object({ id: z.string() }).nullable(),
+  answerChosenAt: z.string().nullable(),
+  labels: LabelConnectionSchema,
+});
+
+const DISCUSSIONS_PROBE_QUERY = `
+  query DiscussionsProbe($owner: String!, $name: String!) {
+    repository(owner: $owner, name: $name) {
+      hasDiscussionsEnabled
+    }
+  }
+`;
+
+const DISCUSSIONS_QUERY = `
+  query FetchDiscussions($owner: String!, $name: String!, $cursor: String) {
+    repository(owner: $owner, name: $name) {
+      discussions(first: 50, after: $cursor, orderBy: {field: UPDATED_AT, direction: ASC}) {
+        pageInfo { hasNextPage endCursor }
+        nodes {
+          id url number title body closedAt createdAt updatedAt
+          author {
+            __typename
+            login
+            url
+            ... on User { id }
+            ... on Bot { id }
+          }
+          category { name emoji isAnswerable }
+          answer { id }
+          answerChosenAt
+          labels(first: 50) {
+            nodes { id name color description }
+            pageInfo { hasNextPage endCursor }
+          }
+        }
+      }
+    }
+  }
+`;
+
+const DISCUSSION_LABELS_QUERY = `
+  query FetchDiscussionLabels($owner: String!, $name: String!, $number: Int!, $cursor: String) {
+    repository(owner: $owner, name: $name) {
+      discussion(number: $number) {
+        labels(first: 50, after: $cursor) {
+          nodes { id name color description }
+          pageInfo { hasNextPage endCursor }
+        }
+      }
+    }
+  }
+`;
+
+export function computeContentHash(title: string, rawBody: string | null): string {
+  const normalizedBody = (rawBody ?? "").replace(/\r\n/g, "\n");
+  return createHash("sha256")
+    .update(`${title}\n\n${normalizedBody}`)
+    .digest("hex");
+}
+
+export async function* fetchDiscussions(
+  owner: string,
+  name: string,
+): AsyncGenerator<ParsedDiscussion> {
+  const probeData = await gh<{ repository: { hasDiscussionsEnabled: boolean } }>(
+    DISCUSSIONS_PROBE_QUERY,
+    { owner, name },
+  );
+  if (!probeData.repository.hasDiscussionsEnabled) return;
+
+  for await (const rawNode of paginate(
+    DISCUSSIONS_QUERY,
+    { owner, name },
+    (data: unknown) => {
+      const d = data as {
+        repository: {
+          discussions: {
+            nodes: unknown[];
+            pageInfo: { hasNextPage: boolean; endCursor: string | null };
+          };
+        };
+      };
+      return d.repository.discussions;
+    },
+  )) {
+    const node = DiscussionNodeSchema.parse(rawNode);
+
+    let author: ParsedUser | null = null;
+    if (node.author !== null) {
+      const { __typename, id, login, url: github_url } = node.author;
+      if ((__typename === "User" || __typename === "Bot") && id !== undefined) {
+        author = {
+          github_node_id: id,
+          login,
+          is_bot: isBot(__typename, login),
+          github_url,
+        };
+      }
+    }
+
+    let labelNodes = node.labels.nodes;
+    let labelPageInfo = node.labels.pageInfo;
+
+    while (labelPageInfo.hasNextPage) {
+      const moreData = await gh<unknown>(DISCUSSION_LABELS_QUERY, {
+        owner,
+        name,
+        number: node.number,
+        cursor: labelPageInfo.endCursor,
+      });
+      const moreConn = (
+        moreData as { repository: { discussion: { labels: unknown } } }
+      ).repository.discussion.labels;
+      const moreParsed = LabelConnectionSchema.parse(moreConn);
+      labelNodes = [...labelNodes, ...moreParsed.nodes];
+      labelPageInfo = moreParsed.pageInfo;
+    }
+
+    const labels: ParsedLabel[] = labelNodes.map((l) => ({
+      github_node_id: l.id,
+      name: l.name,
+      color: l.color,
+      description: l.description,
+    }));
+
+    const content_hash = computeContentHash(node.title, node.body);
+
+    yield {
+      github_node_id: node.id,
+      github_url: node.url,
+      number: node.number,
+      title: node.title,
+      body: (node.body ?? "").replace(/\r\n/g, "\n"),
+      closed_at: node.closedAt ? new Date(node.closedAt) : null,
+      created_at: new Date(node.createdAt),
+      updated_at: new Date(node.updatedAt),
+      content_hash,
+      category_name: node.category?.name ?? null,
+      answer_chosen_at: node.answerChosenAt ? new Date(node.answerChosenAt) : null,
+      author,
+      labels,
+    };
+  }
+}
+
+export async function persistDiscussion(
+  db: Surreal,
+  repo: RepoRef,
+  parsed: ParsedDiscussion,
+): Promise<void> {
+  const repoRef = new StringRecordId(repo.id);
+
+  let authorRef: StringRecordId | undefined;
+  if (parsed.author !== null) {
+    const id = await upsertUser(db, parsed.author);
+    authorRef = new StringRecordId(id);
+  }
+
+  const authorSql = parsed.author !== null ? "$author" : "NONE";
+  const answerChosenAtSql = parsed.answer_chosen_at !== null ? "$answer_chosen_at" : "NONE";
+  const categorySql = parsed.category_name !== null ? "$category" : "NONE";
+
+  const [existing] = await db.query<[Array<{ id: unknown }>]>(
+    "SELECT id FROM discussion WHERE github_node_id = $github_node_id",
+    { github_node_id: parsed.github_node_id },
+  );
+
+  let discussionRecordId: string;
+
+  if (existing.length === 0) {
+    const [created] = await db.query<[Array<{ id: unknown }>]>(
+      `CREATE discussion CONTENT {
+        github_node_id: $github_node_id,
+        github_url: $github_url,
+        repo: $repo,
+        number: $number,
+        title: $title,
+        body: $body,
+        category: ${categorySql},
+        author: ${authorSql},
+        answer_chosen_at: ${answerChosenAtSql},
+        created_at: $created_at,
+        updated_at: $updated_at,
+        deleted_at: NONE,
+        content_hash: $content_hash,
+        embedding: NONE
+      }`,
+      {
+        github_node_id: parsed.github_node_id,
+        github_url: parsed.github_url,
+        repo: repoRef,
+        number: parsed.number,
+        title: parsed.title,
+        body: parsed.body,
+        ...(parsed.category_name !== null ? { category: parsed.category_name } : {}),
+        ...(parsed.author !== null ? { author: authorRef } : {}),
+        ...(parsed.answer_chosen_at !== null ? { answer_chosen_at: parsed.answer_chosen_at } : {}),
+        created_at: parsed.created_at,
+        updated_at: parsed.updated_at,
+        content_hash: parsed.content_hash,
+      },
+    );
+    discussionRecordId = String(created[0].id);
+  } else {
+    discussionRecordId = String(existing[0].id);
+    await db.query(
+      `UPDATE $id SET
+        github_url = $github_url,
+        title = $title,
+        body = $body,
+        category = ${categorySql},
+        author = ${authorSql},
+        answer_chosen_at = ${answerChosenAtSql},
+        updated_at = $updated_at,
+        content_hash = $content_hash`,
+      {
+        id: new StringRecordId(discussionRecordId),
+        github_url: parsed.github_url,
+        title: parsed.title,
+        body: parsed.body,
+        ...(parsed.category_name !== null ? { category: parsed.category_name } : {}),
+        ...(parsed.author !== null ? { author: authorRef } : {}),
+        ...(parsed.answer_chosen_at !== null ? { answer_chosen_at: parsed.answer_chosen_at } : {}),
+        updated_at: parsed.updated_at,
+        content_hash: parsed.content_hash,
+      },
+    );
+  }
+
+  await upsertLabelsAndEdges(db, discussionRecordId, parsed.labels);
+}
+
+export async function resolveDiscussionAnswerLinks(
+  db: Surreal,
+  repo: RepoRef,
+): Promise<{ resolved: number; pending: number }> {
+  // TODO: requires schema additions for answer_node_id + answer record link
+  void db;
+  void repo;
+  return { resolved: 0, pending: 0 };
+}


### PR DESCRIPTION
## Summary

Pure async-generator `fetchDiscussions(owner, name)` and DB-only `persistDiscussion(db, repo, parsed)` for GitHub Discussions, mirroring the shape from #3 (issue fetcher).

Includes graceful handling of repos without Discussions enabled — `fetchDiscussions` first probes `Repository.hasDiscussionsEnabled` and yields nothing if disabled, with no error and no list query issued. Plus a stub `resolveDiscussionAnswerLinks(db, repo)` for `tool sync` (#10) to call later — currently a no-op until the schema gains `answer_node_id` + `answer` record link fields.

## Schema notes (limitations)

The schema's `discussion` table is leaner than #5's design spec. Fields captured from GraphQL but **not persisted** because the schema doesn't carry them:

- `upvote_count` — not on the schema.
- `category_emoji`, `category_is_answerable` — only `category: option<string>` exists (just the name).
- `answer_node_id`, `answer: option<record<comment>>` — not on the schema, so the answer-resolution feature is parked behind `resolveDiscussionAnswerLinks`'s no-op body.

Adding these fields is a follow-up — defer until a real consumer needs them. The persister handles what the schema supports today and stays idempotent.

## Test plan

- [x] `bun run typecheck` — clean.
- [x] `bun test` — 44/44 pass across 10 files (11 new tests in `discussion.test.ts`).
- [x] `hasDiscussionsEnabled = false` short-circuit verified (mock returns false → no list query, no yield).
- [x] Idempotency verified (re-persist same payload, no duplicate `has_label` edges, no duplicate `user` rows).
- [x] Null-author path, category capture, answer_chosen_at capture all covered.
- [ ] `bun run smoke:*` (manual; unaffected by this PR).

## Out of scope

- Comments on discussions (#7).
- Cross-references in body (#8).
- Bot heuristic refinement (#9).
- Label catalog refinement (#6).
- Embedding (#11).
- Schema additions for the deferred fields above.

Closes #5


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds GitHub Discussions ingest with a pure async generator and a DB-only persister, guarded by a `hasDiscussionsEnabled` probe to skip repos without Discussions. Includes idempotent writes, label pagination, and a stub for future answer-link resolution. Closes #5.

- **New Features**
  - `fetchDiscussions(owner, name)`: probes `repository.hasDiscussionsEnabled`, then yields parsed discussions; paginates labels; normalizes body and computes a stable `content_hash`.
  - `persistDiscussion(db, repo, parsed)`: upserts discussion with optional author/category/`answer_chosen_at` stored as NONE when absent; upserts labels and `has_label` edges; idempotent.
  - `resolveDiscussionAnswerLinks(db, repo)`: stub returning `{ resolved: 0, pending: 0 }` until schema adds answer link fields.
  - Deferred schema fields: upvote count, category emoji/isAnswerable, and answer link.

<sup>Written for commit 6500e9db923b47fb8489e83727ebb5df302a1f24. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

