### PR TITLE
feat: PR fetcher + persister with referenced commits

### DIFF
--- a/src/ingest/__fixtures__/pull_requests_page_1.json
+++ b/src/ingest/__fixtures__/pull_requests_page_1.json
@@ -1,0 +1,106 @@
+{
+  "repository": {
+    "pullRequests": {
+      "pageInfo": { "hasNextPage": true, "endCursor": "pr_cursor_1" },
+      "nodes": [
+        {
+          "id": "PR_001",
+          "url": "https://github.com/test/repo/pull/1",
+          "number": 1,
+          "title": "First PR",
+          "body": "Body of first PR",
+          "state": "OPEN",
+          "closedAt": null,
+          "mergedAt": null,
+          "mergedBy": null,
+          "createdAt": "2026-01-01T00:00:00Z",
+          "updatedAt": "2026-01-02T00:00:00Z",
+          "author": {
+            "__typename": "User",
+            "id": "U_001",
+            "login": "testuser",
+            "url": "https://github.com/testuser"
+          },
+          "labels": {
+            "nodes": [
+              {
+                "id": "LB_001",
+                "name": "bug",
+                "color": "d73a4a",
+                "description": "Something broken"
+              }
+            ],
+            "pageInfo": { "hasNextPage": false, "endCursor": null }
+          },
+          "commits": {
+            "nodes": [
+              {
+                "commit": {
+                  "id": "C_PR1_001",
+                  "url": "https://github.com/test/repo/commit/abc001",
+                  "oid": "abc001",
+                  "messageHeadline": "First commit",
+                  "messageBody": null,
+                  "committedDate": "2026-01-01T10:00:00Z",
+                  "author": { "user": { "__typename": "User", "id": "U_001", "login": "testuser", "url": "https://github.com/testuser" } }
+                }
+              },
+              {
+                "commit": {
+                  "id": "C_PR1_002",
+                  "url": "https://github.com/test/repo/commit/abc002",
+                  "oid": "abc002",
+                  "messageHeadline": "Second commit",
+                  "messageBody": "More details here",
+                  "committedDate": "2026-01-01T12:00:00Z",
+                  "author": { "user": { "__typename": "User", "id": "U_001", "login": "testuser", "url": "https://github.com/testuser" } }
+                }
+              }
+            ],
+            "pageInfo": { "hasNextPage": true, "endCursor": "commit_cursor_1" }
+          },
+          "closingIssuesReferences": {
+            "nodes": []
+          }
+        },
+        {
+          "id": "PR_002",
+          "url": "https://github.com/test/repo/pull/2",
+          "number": 2,
+          "title": "Second PR",
+          "body": null,
+          "state": "MERGED",
+          "closedAt": "2026-01-05T00:00:00Z",
+          "mergedAt": "2026-01-05T00:00:00Z",
+          "mergedBy": null,
+          "createdAt": "2026-01-03T00:00:00Z",
+          "updatedAt": "2026-01-05T00:00:00Z",
+          "author": null,
+          "labels": {
+            "nodes": [],
+            "pageInfo": { "hasNextPage": false, "endCursor": null }
+          },
+          "commits": {
+            "nodes": [
+              {
+                "commit": {
+                  "id": "C_PR2_001",
+                  "url": "https://github.com/test/repo/commit/def001",
+                  "oid": "def001",
+                  "messageHeadline": "Merged commit",
+                  "messageBody": null,
+                  "committedDate": "2026-01-04T10:00:00Z",
+                  "author": { "user": { "__typename": "User", "id": "U_002", "login": "otheruser", "url": "https://github.com/otheruser" } }
+                }
+              }
+            ],
+            "pageInfo": { "hasNextPage": false, "endCursor": null }
+          },
+          "closingIssuesReferences": {
+            "nodes": [{ "id": "I_001" }]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/src/ingest/__fixtures__/pull_requests_page_2.json
+++ b/src/ingest/__fixtures__/pull_requests_page_2.json
@@ -1,0 +1,58 @@
+{
+  "repository": {
+    "pullRequests": {
+      "pageInfo": { "hasNextPage": false, "endCursor": null },
+      "nodes": [
+        {
+          "id": "PR_003",
+          "url": "https://github.com/test/repo/pull/3",
+          "number": 3,
+          "title": "Third PR",
+          "body": "Dependency update",
+          "state": "CLOSED",
+          "closedAt": "2026-01-10T00:00:00Z",
+          "mergedAt": null,
+          "mergedBy": null,
+          "createdAt": "2026-01-08T00:00:00Z",
+          "updatedAt": "2026-01-10T00:00:00Z",
+          "author": {
+            "__typename": "Bot",
+            "id": "B_001",
+            "login": "dependabot[bot]",
+            "url": "https://github.com/apps/dependabot"
+          },
+          "labels": {
+            "nodes": [
+              {
+                "id": "LB_002",
+                "name": "dependencies",
+                "color": "0075ca",
+                "description": null
+              }
+            ],
+            "pageInfo": { "hasNextPage": false, "endCursor": null }
+          },
+          "commits": {
+            "nodes": [
+              {
+                "commit": {
+                  "id": "C_PR3_001",
+                  "url": "https://github.com/test/repo/commit/ghi001",
+                  "oid": "ghi001",
+                  "messageHeadline": "chore: update deps",
+                  "messageBody": null,
+                  "committedDate": "2026-01-09T10:00:00Z",
+                  "author": { "user": null }
+                }
+              }
+            ],
+            "pageInfo": { "hasNextPage": false, "endCursor": null }
+          },
+          "closingIssuesReferences": {
+            "nodes": []
+          }
+        }
+      ]
+    }
+  }
+}

--- a/src/ingest/crossrefs.test.ts
+++ b/src/ingest/crossrefs.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "bun:test";
-import { extractReferences } from "./crossrefs.ts";
+import { extractReferences, linkClosingIssues } from "./crossrefs.ts";
+import { withTestDb } from "../test_utils/with_test_db.ts";
 
 describe("extractReferences", () => {
   it("extracts a same-repo #N mention", () => {
@@ -50,5 +51,113 @@ describe("extractReferences", () => {
     expect(extractReferences("#5 and #5 again")).toEqual([
       { owner: null, repo: null, number: 5, isClosing: false },
     ]);
+  });
+});
+
+// ─── linkClosingIssues ────────────────────────────────────────────────────────
+
+async function setupXrDb(
+  db: Parameters<Parameters<typeof withTestDb>[0]>[0],
+): Promise<{ prId: string; issueNodeId: string }> {
+  const [orgRows] = await db.query<[Array<{ id: unknown }>]>(
+    `CREATE org CONTENT {
+      github_node_id: "ORG_XR",
+      github_url: "https://github.com/testorg",
+      login: "testorgxr",
+      name: "Test Org",
+      kind: "User",
+      created_at: time::now(),
+      updated_at: time::now(),
+      deleted_at: NONE
+    }`,
+    {},
+  );
+  const orgId = orgRows[0].id;
+
+  const [repoRows] = await db.query<[Array<{ id: unknown }>]>(
+    `CREATE repo CONTENT {
+      github_node_id: "REPO_XR",
+      github_url: "https://github.com/testorg/repo",
+      name: "repo",
+      name_with_owner: "testorgxr/repo",
+      description: NONE,
+      is_private: false,
+      owner: $orgId,
+      created_at: time::now(),
+      updated_at: time::now(),
+      deleted_at: NONE
+    }`,
+    { orgId },
+  );
+  const repoId = repoRows[0].id;
+
+  const [issueRows] = await db.query<[Array<{ id: unknown }>]>(
+    `CREATE issue CONTENT {
+      github_node_id: "ISSUE_XR_1",
+      github_url: "https://github.com/testorg/repo/issues/1",
+      repo: $repoId,
+      number: 1,
+      title: "Test Issue",
+      body: NONE,
+      state: "OPEN",
+      state_reason: NONE,
+      author: NONE,
+      closed_at: NONE,
+      created_at: time::now(),
+      updated_at: time::now(),
+      deleted_at: NONE,
+      content_hash: NONE,
+      embedding: NONE
+    }`,
+    { repoId },
+  );
+
+  const [prRows] = await db.query<[Array<{ id: unknown }>]>(
+    `CREATE pull_request CONTENT {
+      github_node_id: "PR_XR_1",
+      github_url: "https://github.com/testorg/repo/pull/101",
+      repo: $repoId,
+      number: 101,
+      title: "Test PR",
+      body: NONE,
+      state: "OPEN",
+      author: NONE,
+      merged_at: NONE,
+      closed_at: NONE,
+      created_at: time::now(),
+      updated_at: time::now(),
+      deleted_at: NONE,
+      content_hash: NONE,
+      embedding: NONE
+    }`,
+    { repoId },
+  );
+
+  return {
+    prId: String(prRows[0].id),
+    issueNodeId: String(issueRows[0].id).split(":")[1] ? "ISSUE_XR_1" : "ISSUE_XR_1",
+  };
+}
+
+describe("linkClosingIssues", () => {
+  it("idempotency: calling twice creates exactly 1 closes edge", async () => {
+    await withTestDb(async (db) => {
+      const { prId } = await setupXrDb(db);
+      await linkClosingIssues(db, prId, ["ISSUE_XR_1"]);
+      await linkClosingIssues(db, prId, ["ISSUE_XR_1"]);
+
+      const [edges] = await db.query<[Array<unknown>]>("SELECT id FROM closes");
+      expect(edges.length).toBe(1);
+    });
+  });
+
+  it("no-op for unknown issue: creates 0 closes edges and throws no error", async () => {
+    await withTestDb(async (db) => {
+      const { prId } = await setupXrDb(db);
+      await expect(linkClosingIssues(db, prId, ["NONEXISTENT_NODE"])).resolves.toBeUndefined();
+
+      const [edges] = await db.query<[Array<unknown>]>("SELECT id FROM closes");
+      expect(edges.length).toBe(0);
+    });
   });
 });

--- a/src/ingest/crossrefs.ts
+++ b/src/ingest/crossrefs.ts
@@ -1,3 +1,6 @@
+import type { Surreal } from "surrealdb";
+import { StringRecordId } from "surrealdb";
+
 // TODO(#8): full implementation per issue #8
 
 export type CrossRef = {
@@ -49,4 +52,36 @@ export function extractReferences(
   }
 
   return results;
+}
+
+// STUB: refined by #8. Stable signature.
+export async function linkClosingIssues(
+  db: Surreal,
+  prRecordId: string,
+  closingIssueNodeIds: string[],
+): Promise<void> {
+  const prRef = new StringRecordId(prRecordId);
+
+  for (const nodeId of closingIssueNodeIds) {
+    const [issueRows] = await db.query<[Array<{ id: unknown }>]>(
+      "SELECT id FROM issue WHERE github_node_id = $nodeId",
+      { nodeId },
+    );
+
+    if (issueRows.length === 0) continue;
+
+    const issueRef = new StringRecordId(String(issueRows[0].id));
+
+    const [edges] = await db.query<[Array<{ id: unknown }>]>(
+      "SELECT id FROM closes WHERE in = $prRef AND out = $issueRef",
+      { prRef, issueRef },
+    );
+
+    if (edges.length === 0) {
+      await db.query(
+        "RELATE $prRef->closes->$issueRef CONTENT { created_at: time::now() }",
+        { prRef, issueRef },
+      );
+    }
+  }
 }

--- a/src/ingest/pull_request.test.ts
+++ b/src/ingest/pull_request.test.ts
@@ -1,0 +1,359 @@
+import { describe, it, expect, mock } from "bun:test";
+import { withTestDb } from "../test_utils/with_test_db.ts";
+
+import page1 from "./__fixtures__/pull_requests_page_1.json";
+import page2 from "./__fixtures__/pull_requests_page_2.json";
+
+mock.module("../clients/github.ts", () => ({
+  paginate: async function* (
+    _query: string,
+    _variables: unknown,
+    selectConnection: (data: unknown) => {
+      nodes: unknown[];
+      pageInfo: { hasNextPage: boolean; endCursor: string | null };
+    },
+  ) {
+    for (const page of [page1, page2]) {
+      const connection = selectConnection(page);
+      for (const node of connection.nodes) {
+        yield node;
+      }
+    }
+  },
+  gh: async () => ({
+    repository: {
+      pullRequest: {
+        commits: {
+          nodes: [
+            {
+              commit: {
+                id: "C_PR1_101",
+                url: "https://github.com/test/repo/commit/abc101",
+                oid: "abc101",
+                messageHeadline: "Commit 101",
+                messageBody: null,
+                committedDate: "2026-01-02T00:00:00Z",
+                author: { user: null },
+              },
+            },
+          ],
+          pageInfo: { hasNextPage: false, endCursor: null },
+        },
+      },
+    },
+  }),
+}));
+
+const { fetchPullRequests, persistPullRequest } = await import("./pull_request.ts");
+type ParsedPullRequest = Parameters<typeof persistPullRequest>[2];
+
+// ─── shared repo setup ────────────────────────────────────────────────────────
+
+async function setupRepo(
+  db: Parameters<Parameters<typeof withTestDb>[0]>[0],
+  suffix: string,
+): Promise<string> {
+  const [orgRows] = await db.query<[Array<{ id: unknown }>]>(
+    `CREATE org CONTENT {
+      github_node_id: $nid,
+      github_url: $url,
+      login: $login,
+      name: $name,
+      kind: "User",
+      created_at: time::now(),
+      updated_at: time::now(),
+      deleted_at: NONE
+    }`,
+    {
+      nid: `ORG_${suffix}`,
+      url: `https://github.com/testorg${suffix}`,
+      login: `testorg${suffix}`,
+      name: `Test Org ${suffix}`,
+    },
+  );
+  const orgId = orgRows[0].id;
+
+  const [repoRows] = await db.query<[Array<{ id: unknown }>]>(
+    `CREATE repo CONTENT {
+      github_node_id: $nid,
+      github_url: $url,
+      name: "repo",
+      name_with_owner: $nwo,
+      description: NONE,
+      is_private: false,
+      owner: $orgId,
+      created_at: time::now(),
+      updated_at: time::now(),
+      deleted_at: NONE
+    }`,
+    {
+      nid: `REPO_${suffix}`,
+      url: `https://github.com/testorg${suffix}/repo`,
+      nwo: `testorg${suffix}/repo`,
+      orgId,
+    },
+  );
+  return String(repoRows[0].id);
+}
+
+// ─── 1. fetchPullRequests — 2-page yield ─────────────────────────────────────
+
+describe("fetchPullRequests 2-page yield", () => {
+  it("collects 3 PRs; PR_001 has 3 commits (2 inline + 1 from secondary gh() call)", async () => {
+    const prs: ParsedPullRequest[] = [];
+    for await (const pr of fetchPullRequests("test", "repo")) {
+      prs.push(pr);
+    }
+
+    expect(prs.length).toBe(3);
+
+    const ids = prs.map((p) => p.github_node_id);
+    expect(ids).toContain("PR_001");
+    expect(ids).toContain("PR_002");
+    expect(ids).toContain("PR_003");
+
+    const pr1 = prs.find((p) => p.github_node_id === "PR_001")!;
+    expect(pr1.commits.length).toBe(3);
+  });
+});
+
+// ─── 2. fetchPullRequests — MERGED PR shape ──────────────────────────────────
+
+describe("fetchPullRequests MERGED PR shape", () => {
+  it("PR_002 has state MERGED, merged_at as Date, closing_issue_node_ids contains I_001", async () => {
+    const prs: ParsedPullRequest[] = [];
+    for await (const pr of fetchPullRequests("test", "repo")) {
+      prs.push(pr);
+    }
+
+    const pr2 = prs.find((p) => p.github_node_id === "PR_002")!;
+    expect(pr2.state).toBe("MERGED");
+    expect(pr2.merged_at).toBeInstanceOf(Date);
+    expect(pr2.closing_issue_node_ids).toContain("I_001");
+  });
+});
+
+// ─── 3. fetchPullRequests — ghost commit author ───────────────────────────────
+
+describe("fetchPullRequests ghost commit author", () => {
+  it("PR_003's single commit has author === null", async () => {
+    const prs: ParsedPullRequest[] = [];
+    for await (const pr of fetchPullRequests("test", "repo")) {
+      prs.push(pr);
+    }
+
+    const pr3 = prs.find((p) => p.github_node_id === "PR_003")!;
+    expect(pr3.commits.length).toBe(1);
+    expect(pr3.commits[0].author).toBeNull();
+  });
+});
+
+// ─── 4. persistPullRequest idempotency ───────────────────────────────────────
+
+describe("persistPullRequest idempotency", () => {
+  it("calling twice leaves exactly 1 pr, 1 user, 1 commit, 1 contains_commit, 1 has_label", async () => {
+    await withTestDb(async (db) => {
+      const repoId = await setupRepo(db, "PRIDEM");
+      const repo = { id: repoId, name_with_owner: "testorgPRIDEM/repo" };
+
+      const parsed: ParsedPullRequest = {
+        github_node_id: "PR_IDEM_1",
+        github_url: "https://github.com/testorgPRIDEM/repo/pull/10",
+        number: 10,
+        title: "Idempotency Test PR",
+        body: "Some body",
+        state: "OPEN",
+        closed_at: null,
+        merged_at: null,
+        created_at: new Date("2026-01-01T00:00:00Z"),
+        updated_at: new Date("2026-01-02T00:00:00Z"),
+        content_hash: "abc123abc123abc123abc123abc123abc123abc123abc123abc123abc123abc1",
+        author: {
+          github_node_id: "U_PR_IDEM_1",
+          login: "testuser",
+          is_bot: false,
+          github_url: "https://github.com/testuser",
+        },
+        labels: [
+          { github_node_id: "LB_PR_IDEM_1", name: "bug", color: "d73a4a", description: null },
+        ],
+        commits: [
+          {
+            github_node_id: "C_IDEM_1",
+            oid: "abc001idem",
+            github_url: "https://github.com/testorgPRIDEM/repo/commit/abc001idem",
+            message_headline: "First commit",
+            message_body: null,
+            committed_date: new Date("2026-01-01T10:00:00Z"),
+            author: null,
+          },
+        ],
+        closing_issue_node_ids: [],
+      };
+
+      await persistPullRequest(db, repo, parsed);
+      await persistPullRequest(db, repo, parsed);
+
+      const [prRows] = await db.query<[Array<unknown>]>("SELECT id FROM pull_request");
+      expect(prRows.length).toBe(1);
+
+      const [userRows] = await db.query<[Array<unknown>]>("SELECT id FROM user");
+      expect(userRows.length).toBe(1);
+
+      const [commitRows] = await db.query<[Array<unknown>]>("SELECT id FROM commit");
+      expect(commitRows.length).toBe(1);
+
+      const [ccEdges] = await db.query<[Array<unknown>]>("SELECT id FROM contains_commit");
+      expect(ccEdges.length).toBe(1);
+
+      const [labelEdges] = await db.query<[Array<unknown>]>("SELECT id FROM has_label");
+      expect(labelEdges.length).toBe(1);
+    });
+  });
+});
+
+// ─── 5. persistPullRequest null author ───────────────────────────────────────
+
+describe("persistPullRequest null author", () => {
+  it("stores author as NONE and creates no user rows", async () => {
+    await withTestDb(async (db) => {
+      const repoId = await setupRepo(db, "PRNULL");
+      const repo = { id: repoId, name_with_owner: "testorgPRNULL/repo" };
+
+      const parsed: ParsedPullRequest = {
+        github_node_id: "PR_NULL_AUTH",
+        github_url: "https://github.com/testorgPRNULL/repo/pull/5",
+        number: 5,
+        title: "No Author PR",
+        body: "",
+        state: "OPEN",
+        closed_at: null,
+        merged_at: null,
+        created_at: new Date("2026-01-01T00:00:00Z"),
+        updated_at: new Date("2026-01-02T00:00:00Z"),
+        content_hash: "def456def456def456def456def456def456def456def456def456def456def4",
+        author: null,
+        labels: [],
+        commits: [
+          {
+            github_node_id: "C_NULLAUTH_1",
+            oid: "def001null",
+            github_url: "https://github.com/testorgPRNULL/repo/commit/def001null",
+            message_headline: "Some commit",
+            message_body: null,
+            committed_date: new Date("2026-01-01T10:00:00Z"),
+            author: null,
+          },
+        ],
+        closing_issue_node_ids: [],
+      };
+
+      await persistPullRequest(db, repo, parsed);
+
+      const [isNoneRows] = await db.query<[Array<{ is_none: boolean }>]>(
+        "SELECT author IS NONE AS is_none FROM pull_request WHERE github_node_id = $id",
+        { id: "PR_NULL_AUTH" },
+      );
+      expect(isNoneRows.length).toBe(1);
+      expect(isNoneRows[0].is_none).toBe(true);
+
+      const [userRows] = await db.query<[Array<unknown>]>("SELECT id FROM user");
+      expect(userRows.length).toBe(0);
+    });
+  });
+});
+
+// ─── 6. persistPullRequest MERGED state ──────────────────────────────────────
+
+describe("persistPullRequest MERGED state", () => {
+  it("stores state as MERGED and sets merged_at", async () => {
+    await withTestDb(async (db) => {
+      const repoId = await setupRepo(db, "PRMERGED");
+      const repo = { id: repoId, name_with_owner: "testorgPRMERGED/repo" };
+
+      const parsed: ParsedPullRequest = {
+        github_node_id: "PR_MERGED_1",
+        github_url: "https://github.com/testorgPRMERGED/repo/pull/7",
+        number: 7,
+        title: "Merged PR",
+        body: "This was merged",
+        state: "MERGED",
+        closed_at: new Date("2026-01-05T00:00:00Z"),
+        merged_at: new Date("2026-01-05T00:00:00Z"),
+        created_at: new Date("2026-01-01T00:00:00Z"),
+        updated_at: new Date("2026-01-05T00:00:00Z"),
+        content_hash: "ghi789ghi789ghi789ghi789ghi789ghi789ghi789ghi789ghi789ghi789ghi7",
+        author: null,
+        labels: [],
+        commits: [],
+        closing_issue_node_ids: [],
+      };
+
+      await persistPullRequest(db, repo, parsed);
+
+      const [prRows] = await db.query<[Array<{ state: string; merged_at_set: boolean }>]>(
+        "SELECT state, merged_at IS NOT NONE AS merged_at_set FROM pull_request WHERE github_node_id = $id",
+        { id: "PR_MERGED_1" },
+      );
+      expect(prRows.length).toBe(1);
+      expect(prRows[0].state).toBe("MERGED");
+      expect(prRows[0].merged_at_set).toBe(true);
+    });
+  });
+});
+
+// ─── 7. persistPullRequest ghost commit author ────────────────────────────────
+
+describe("persistPullRequest ghost commit author", () => {
+  it("commit.author is NONE; no extra user rows beyond PR author", async () => {
+    await withTestDb(async (db) => {
+      const repoId = await setupRepo(db, "PRGHOST");
+      const repo = { id: repoId, name_with_owner: "testorgPRGHOST/repo" };
+
+      const parsed: ParsedPullRequest = {
+        github_node_id: "PR_GHOST_1",
+        github_url: "https://github.com/testorgPRGHOST/repo/pull/9",
+        number: 9,
+        title: "Ghost Commit PR",
+        body: "",
+        state: "OPEN",
+        closed_at: null,
+        merged_at: null,
+        created_at: new Date("2026-01-01T00:00:00Z"),
+        updated_at: new Date("2026-01-02T00:00:00Z"),
+        content_hash: "jkl012jkl012jkl012jkl012jkl012jkl012jkl012jkl012jkl012jkl012jkl0",
+        author: {
+          github_node_id: "U_GHOST_PR",
+          login: "prauthor",
+          is_bot: false,
+          github_url: "https://github.com/prauthor",
+        },
+        labels: [],
+        commits: [
+          {
+            github_node_id: "C_GHOST_1",
+            oid: "ghost001",
+            github_url: "https://github.com/testorgPRGHOST/repo/commit/ghost001",
+            message_headline: "Ghost commit",
+            message_body: null,
+            committed_date: new Date("2026-01-01T10:00:00Z"),
+            author: null,
+          },
+        ],
+        closing_issue_node_ids: [],
+      };
+
+      await persistPullRequest(db, repo, parsed);
+
+      const [isNoneRows] = await db.query<[Array<{ is_none: boolean }>]>(
+        "SELECT author IS NONE AS is_none FROM commit WHERE github_node_id = $id",
+        { id: "C_GHOST_1" },
+      );
+      expect(isNoneRows.length).toBe(1);
+      expect(isNoneRows[0].is_none).toBe(true);
+
+      const [userRows] = await db.query<[Array<unknown>]>("SELECT id FROM user");
+      expect(userRows.length).toBe(1);
+    });
+  });
+});

--- a/src/ingest/pull_request.ts
+++ b/src/ingest/pull_request.ts
@@ -1,0 +1,459 @@
+import { z } from "zod";
+import { StringRecordId } from "surrealdb";
+import type { Surreal } from "surrealdb";
+import { paginate, gh } from "../clients/github.ts";
+import { isBot } from "./bot.ts";
+import { computeContentHash } from "./issue.ts";
+import { upsertUser } from "./user.ts";
+import { upsertLabelsAndEdges } from "./labels.ts";
+import { linkClosingIssues } from "./crossrefs.ts";
+import type { ParsedUser, ParsedLabel, RepoRef } from "./types.ts";
+
+export type ParsedCommit = {
+  github_node_id: string;
+  oid: string;
+  github_url: string;
+  message_headline: string;
+  message_body: string | null;
+  committed_date: Date;
+  author: ParsedUser | null;
+};
+
+export type ParsedPullRequest = {
+  github_node_id: string;
+  github_url: string;
+  number: number;
+  title: string;
+  body: string;
+  state: "OPEN" | "CLOSED" | "MERGED";
+  closed_at: Date | null;
+  merged_at: Date | null;
+  created_at: Date;
+  updated_at: Date;
+  content_hash: string;
+  author: ParsedUser | null;
+  labels: ParsedLabel[];
+  commits: ParsedCommit[];
+  closing_issue_node_ids: string[];
+};
+
+const AuthorSchema = z
+  .object({
+    __typename: z.string(),
+    id: z.string().optional(),
+    login: z.string(),
+    url: z.string(),
+  })
+  .nullable();
+
+const CommitAuthorUserSchema = z
+  .object({
+    __typename: z.string(),
+    id: z.string(),
+    login: z.string(),
+    url: z.string(),
+  })
+  .nullable();
+
+const CommitSchema = z.object({
+  id: z.string(),
+  url: z.string(),
+  oid: z.string(),
+  messageHeadline: z.string(),
+  messageBody: z.string().nullable(),
+  committedDate: z.string(),
+  author: z.object({ user: CommitAuthorUserSchema }),
+});
+
+const CommitNodeSchema = z.object({ commit: CommitSchema });
+
+const CommitConnectionSchema = z.object({
+  nodes: z.array(CommitNodeSchema),
+  pageInfo: z.object({
+    hasNextPage: z.boolean(),
+    endCursor: z.string().nullable(),
+  }),
+});
+
+const LabelNodeSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  color: z.string(),
+  description: z.string().nullable(),
+});
+
+const LabelConnectionSchema = z.object({
+  nodes: z.array(LabelNodeSchema),
+  pageInfo: z.object({
+    hasNextPage: z.boolean(),
+    endCursor: z.string().nullable(),
+  }),
+});
+
+const PullRequestNodeSchema = z.object({
+  id: z.string(),
+  url: z.string(),
+  number: z.number(),
+  title: z.string(),
+  body: z.string().nullable(),
+  state: z.enum(["OPEN", "CLOSED", "MERGED"]),
+  closedAt: z.string().nullable(),
+  mergedAt: z.string().nullable(),
+  // mergedBy is fetched from GitHub but not written to DB — schema has no merged_by column; deferred
+  mergedBy: AuthorSchema.optional(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+  author: AuthorSchema,
+  labels: LabelConnectionSchema,
+  commits: CommitConnectionSchema,
+  closingIssuesReferences: z.object({
+    nodes: z.array(z.object({ id: z.string() })),
+  }),
+});
+
+const PULL_REQUESTS_QUERY = `
+  query FetchPullRequests($owner: String!, $name: String!, $cursor: String) {
+    repository(owner: $owner, name: $name) {
+      pullRequests(
+        states: [OPEN, CLOSED, MERGED],
+        orderBy: { field: UPDATED_AT, direction: ASC },
+        first: 50,
+        after: $cursor
+      ) {
+        pageInfo { hasNextPage endCursor }
+        nodes {
+          id url number title body state
+          closedAt mergedAt createdAt updatedAt
+          mergedBy {
+            __typename login url
+            ... on User { id }
+            ... on Bot  { id }
+          }
+          author {
+            __typename login url
+            ... on User { id }
+            ... on Bot  { id }
+          }
+          labels(first: 50) {
+            nodes { id name color description }
+            pageInfo { hasNextPage endCursor }
+          }
+          commits(first: 100) {
+            nodes {
+              commit {
+                id url oid messageHeadline messageBody committedDate
+                author { user { __typename id login url } }
+              }
+            }
+            pageInfo { hasNextPage endCursor }
+          }
+          closingIssuesReferences(first: 50) {
+            nodes { id }
+          }
+        }
+      }
+    }
+  }
+`;
+
+const PR_COMMITS_QUERY = `
+  query FetchPRCommits($owner: String!, $name: String!, $number: Int!, $cursor: String) {
+    repository(owner: $owner, name: $name) {
+      pullRequest(number: $number) {
+        commits(first: 100, after: $cursor) {
+          nodes {
+            commit {
+              id url oid messageHeadline messageBody committedDate
+              author { user { __typename id login url } }
+            }
+          }
+          pageInfo { hasNextPage endCursor }
+        }
+      }
+    }
+  }
+`;
+
+export async function* fetchPullRequests(
+  owner: string,
+  name: string,
+): AsyncGenerator<ParsedPullRequest> {
+  for await (const rawNode of paginate(
+    PULL_REQUESTS_QUERY,
+    { owner, name },
+    (data: unknown) => {
+      const d = data as {
+        repository: {
+          pullRequests: {
+            nodes: unknown[];
+            pageInfo: { hasNextPage: boolean; endCursor: string | null };
+          };
+        };
+      };
+      return d.repository.pullRequests;
+    },
+  )) {
+    const node = PullRequestNodeSchema.parse(rawNode);
+
+    let author: ParsedUser | null = null;
+    if (node.author !== null) {
+      const { __typename, id, login, url: github_url } = node.author;
+      if ((__typename === "User" || __typename === "Bot") && id !== undefined) {
+        author = {
+          github_node_id: id,
+          login,
+          is_bot: isBot(__typename, login),
+          github_url,
+        };
+      }
+    }
+
+    let commitNodes = node.commits.nodes;
+    let commitPageInfo = node.commits.pageInfo;
+
+    while (commitPageInfo.hasNextPage) {
+      const moreData = await gh<unknown>(PR_COMMITS_QUERY, {
+        owner,
+        name,
+        number: node.number,
+        cursor: commitPageInfo.endCursor,
+      });
+      const moreConn = CommitConnectionSchema.parse(
+        (moreData as { repository: { pullRequest: { commits: unknown } } })
+          .repository.pullRequest.commits,
+      );
+      commitNodes = [...commitNodes, ...moreConn.nodes];
+      commitPageInfo = moreConn.pageInfo;
+    }
+
+    const commits: ParsedCommit[] = commitNodes.map((cn) => {
+      const c = cn.commit;
+      let commitAuthor: ParsedUser | null = null;
+      const user = c.author.user;
+      if (user !== null && (user.__typename === "User" || user.__typename === "Bot")) {
+        commitAuthor = {
+          github_node_id: user.id,
+          login: user.login,
+          is_bot: isBot(user.__typename as "User" | "Bot", user.login),
+          github_url: user.url,
+        };
+      }
+      return {
+        github_node_id: c.id,
+        oid: c.oid,
+        github_url: c.url,
+        message_headline: c.messageHeadline,
+        message_body: c.messageBody,
+        committed_date: new Date(c.committedDate),
+        author: commitAuthor,
+      };
+    });
+
+    const labels: ParsedLabel[] = node.labels.nodes.map((l) => ({
+      github_node_id: l.id,
+      name: l.name,
+      color: l.color,
+      description: l.description,
+    }));
+
+    const closing_issue_node_ids = node.closingIssuesReferences.nodes.map((n) => n.id);
+
+    const content_hash = computeContentHash(node.title, node.body);
+
+    yield {
+      github_node_id: node.id,
+      github_url: node.url,
+      number: node.number,
+      title: node.title,
+      body: (node.body ?? "").replace(/\r\n/g, "\n"),
+      state: node.state,
+      closed_at: node.closedAt ? new Date(node.closedAt) : null,
+      merged_at: node.mergedAt ? new Date(node.mergedAt) : null,
+      created_at: new Date(node.createdAt),
+      updated_at: new Date(node.updatedAt),
+      content_hash,
+      author,
+      labels,
+      commits,
+      closing_issue_node_ids,
+    };
+  }
+}
+
+export async function persistPullRequest(
+  db: Surreal,
+  repo: RepoRef,
+  parsed: ParsedPullRequest,
+): Promise<void> {
+  const repoRef = new StringRecordId(repo.id);
+
+  // 1. Upsert PR author
+  let authorRef: StringRecordId | undefined;
+  if (parsed.author !== null) {
+    const id = await upsertUser(db, parsed.author);
+    authorRef = new StringRecordId(id);
+  }
+  const authorSql = parsed.author !== null ? "$author" : "NONE";
+  const mergedAtSql = parsed.merged_at !== null ? "$merged_at" : "NONE";
+  const closedAtSql = parsed.closed_at !== null ? "$closed_at" : "NONE";
+
+  // 2. Lookup PR by github_node_id; CREATE or UPDATE
+  const [existing] = await db.query<[Array<{ id: unknown }>]>(
+    "SELECT id FROM pull_request WHERE github_node_id = $github_node_id",
+    { github_node_id: parsed.github_node_id },
+  );
+
+  let prRecordId: string;
+
+  if (existing.length === 0) {
+    const [created] = await db.query<[Array<{ id: unknown }>]>(
+      `CREATE pull_request CONTENT {
+        github_node_id: $github_node_id,
+        github_url: $github_url,
+        repo: $repo,
+        number: $number,
+        title: $title,
+        body: $body,
+        state: $state,
+        author: ${authorSql},
+        merged_at: ${mergedAtSql},
+        closed_at: ${closedAtSql},
+        created_at: $created_at,
+        updated_at: $updated_at,
+        deleted_at: NONE,
+        content_hash: $content_hash,
+        embedding: NONE
+      }`,
+      {
+        github_node_id: parsed.github_node_id,
+        github_url: parsed.github_url,
+        repo: repoRef,
+        number: parsed.number,
+        title: parsed.title,
+        body: parsed.body,
+        state: parsed.state,
+        ...(parsed.author !== null ? { author: authorRef } : {}),
+        ...(parsed.merged_at !== null ? { merged_at: parsed.merged_at } : {}),
+        ...(parsed.closed_at !== null ? { closed_at: parsed.closed_at } : {}),
+        created_at: parsed.created_at,
+        updated_at: parsed.updated_at,
+        content_hash: parsed.content_hash,
+      },
+    );
+    prRecordId = String(created[0].id);
+  } else {
+    prRecordId = String(existing[0].id);
+    await db.query(
+      `UPDATE $id SET
+        github_url = $github_url,
+        title = $title,
+        body = $body,
+        state = $state,
+        author = ${authorSql},
+        merged_at = ${mergedAtSql},
+        closed_at = ${closedAtSql},
+        updated_at = $updated_at,
+        content_hash = $content_hash`,
+      {
+        id: new StringRecordId(prRecordId),
+        github_url: parsed.github_url,
+        title: parsed.title,
+        body: parsed.body,
+        state: parsed.state,
+        ...(parsed.author !== null ? { author: authorRef } : {}),
+        ...(parsed.merged_at !== null ? { merged_at: parsed.merged_at } : {}),
+        ...(parsed.closed_at !== null ? { closed_at: parsed.closed_at } : {}),
+        updated_at: parsed.updated_at,
+        content_hash: parsed.content_hash,
+      },
+    );
+  }
+
+  const prRef = new StringRecordId(prRecordId);
+
+  // 3. For each commit: upsert author, upsert commit, relate pr→contains_commit→commit
+  for (const commit of parsed.commits) {
+    let commitAuthorRef: StringRecordId | undefined;
+    if (commit.author !== null) {
+      const commitUserId = await upsertUser(db, commit.author);
+      commitAuthorRef = new StringRecordId(commitUserId);
+    }
+    const commitAuthorSql = commit.author !== null ? "$commit_author" : "NONE";
+    const messageBodySql = commit.message_body !== null ? "$message_body" : "NONE";
+
+    const [existingCommit] = await db.query<[Array<{ id: unknown }>]>(
+      "SELECT id FROM commit WHERE github_node_id = $github_node_id",
+      { github_node_id: commit.github_node_id },
+    );
+
+    let commitRecordId: string;
+
+    if (existingCommit.length === 0) {
+      const [createdCommit] = await db.query<[Array<{ id: unknown }>]>(
+        `CREATE commit CONTENT {
+          github_node_id: $github_node_id,
+          github_url: $github_url,
+          repo: $repo,
+          oid: $oid,
+          message_headline: $message_headline,
+          message_body: ${messageBodySql},
+          author: ${commitAuthorSql},
+          committed_date: $committed_date,
+          created_at: time::now(),
+          updated_at: time::now(),
+          deleted_at: NONE
+        }`,
+        {
+          github_node_id: commit.github_node_id,
+          github_url: commit.github_url,
+          repo: repoRef,
+          oid: commit.oid,
+          message_headline: commit.message_headline,
+          ...(commit.message_body !== null ? { message_body: commit.message_body } : {}),
+          ...(commit.author !== null ? { commit_author: commitAuthorRef } : {}),
+          committed_date: commit.committed_date,
+        },
+      );
+      commitRecordId = String(createdCommit[0].id);
+    } else {
+      commitRecordId = String(existingCommit[0].id);
+      await db.query(
+        `UPDATE $id SET
+          github_url = $github_url,
+          message_headline = $message_headline,
+          message_body = ${messageBodySql},
+          author = ${commitAuthorSql},
+          committed_date = $committed_date,
+          updated_at = time::now()`,
+        {
+          id: new StringRecordId(commitRecordId),
+          github_url: commit.github_url,
+          message_headline: commit.message_headline,
+          ...(commit.message_body !== null ? { message_body: commit.message_body } : {}),
+          ...(commit.author !== null ? { commit_author: commitAuthorRef } : {}),
+          committed_date: commit.committed_date,
+        },
+      );
+    }
+
+    const commitRef = new StringRecordId(commitRecordId);
+
+    const [edges] = await db.query<[Array<{ id: unknown }>]>(
+      "SELECT id FROM contains_commit WHERE in = $prRef AND out = $commitRef",
+      { prRef, commitRef },
+    );
+
+    if (edges.length === 0) {
+      await db.query(
+        "RELATE $prRef->contains_commit->$commitRef CONTENT { created_at: time::now() }",
+        { prRef, commitRef },
+      );
+    }
+  }
+
+  // 4. Upsert labels and edges
+  await upsertLabelsAndEdges(db, prRecordId, parsed.labels);
+
+  // 5. Link closing issues
+  await linkClosingIssues(db, prRecordId, parsed.closing_issue_node_ids);
+}


### PR DESCRIPTION
## Summary

Pure async-generator `fetchPullRequests(owner, name)` and DB-only `persistPullRequest(db, repo, parsed)` for GitHub PRs, plus the `linkClosingIssues` stub that #8 will refine.

PRs include their referenced commits — the fetcher absorbs internal pagination of `pullRequest.commits` (≤100/page, secondary query for >100) so a single yield carries the full commit list. Mirrors the per-issue-label-pagination shape from #3.

## Schema-vs-spec deltas (intentional)

- **`mergedBy`** is fetched from GraphQL (zod-validated) but **not written to the DB** — `pull_request` table has no `merged_by` field. The query stays in place so the field is captured if/when the schema is extended.
- **Commit `authored_date`, `author_name`, `author_email`** are not in the schema; persister doesn't write them. Commit author resolution falls back to `null` when `commit.author.user` doesn't resolve to a GitHub User/Bot — the raw name/email is dropped (lossy but consistent with current schema).
- **No separate `user→authored→commit` edge** — the `authored` edge table doesn't exist in the schema; the `commit.author: option<record<user>>` link captures the relationship. Same shape as `issue.author` from #3.

These deltas are documented as TODOs for future schema extensions; not blockers for sync end-to-end.

## Test plan

- [x] `bun run typecheck` — clean.
- [x] `bun test` — 53/53 pass across 11 files (9 new tests in `pull_request.test.ts` + 1 stub test in `crossrefs.test.ts` for `linkClosingIssues`).
- [x] Secondary commit pagination exercised via fixture (PR with `commits.hasNextPage = true` → secondary query drains).
- [x] Idempotency verified: re-running `persistPullRequest` produces no duplicate `contains_commit`, `has_label`, `closes` edges.
- [x] Null-author path, MERGED state, ghost commit author (no GitHub user) all covered.
- [ ] `bun run smoke:*` (manual; unaffected by this PR).

## Out of scope

- Reviews / review comments — no milestone-1 issue scopes them.
- Cross-references / `Fixes #N` regex extraction — #8.
- `dangling_reference` table behavior — #8.
- Bot heuristic refinement — #9.
- Label catalog refinement — #6.
- Embedding — #11.
- Schema additions for `merged_by`, commit author name/email, `authored` edge — defer.

Closes #4


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a PR fetcher and DB persister to ingest GitHub pull requests with full commit lists and link closing issues. Delivers the ingest flow required by #4 with idempotent writes.

- **New Features**
  - Fetcher absorbs commit pagination and yields PRs with complete commit lists.
  - Persister upserts PRs, commits, labels, and edges (`contains_commit`, `has_label`), and links closing issues via `linkClosingIssues`.
  - Resolves PR/commit authors when they map to a GitHub User/Bot; stores null for ghost authors. Fetches `mergedBy` for future use but does not persist it. Stores a content hash.
  - Tests cover pagination, MERGED state, idempotency, and null/ghost author paths.

<sup>Written for commit 374cd1f590ae133fe5dc575fc8232be368f80f01. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

