### PR TITLE
feat: bot detection canonical (doc polish + truth-table tests)

### DIFF
--- a/src/ingest/bot.test.ts
+++ b/src/ingest/bot.test.ts
@@ -10,7 +10,23 @@ describe("isBot", () => {
     expect(isBot("User", "dependabot[bot]")).toBe(true);
   });
 
+  it("returns true for github-actions[bot] login", () => {
+    expect(isBot("User", "github-actions[bot]")).toBe(true);
+  });
+
+  it("returns true for renovate[bot] login", () => {
+    expect(isBot("User", "renovate[bot]")).toBe(true);
+  });
+
   it("returns false for regular user", () => {
     expect(isBot("User", "lfnovo")).toBe(false);
+  });
+
+  it("returns false for Mergify-Bot (no allowlist, suffix check fails)", () => {
+    expect(isBot("User", "Mergify-Bot")).toBe(false);
+  });
+
+  it("returns false for empty login", () => {
+    expect(isBot("User", "")).toBe(false);
   });
 });

--- a/src/ingest/bot.ts
+++ b/src/ingest/bot.ts
@@ -1,4 +1,20 @@
-// STUB: refined by #9. Stable signature.
-export function isBot(typename: "User" | "Bot", login: string): boolean {
+/**
+ * Single source of truth for `user.is_bot`. Used by the embed phase (#11) to
+ * skip bot-authored content per the "Bots are ingested but not embedded"
+ * principle in ARCHITECTURE.md.
+ *
+ * Rule:
+ *   - GraphQL author with __typename === "Bot"  → bot
+ *   - login ending in "[bot]"                   → bot
+ *   - everything else                           → not bot
+ *
+ * Manual overrides (`is_bot_override`) and known-bot allowlists (e.g.
+ * `mergify-bot`, `codecov-commenter`) are deliberately not implemented;
+ * defer-until-it-hurts. Revisit when a real case demands it.
+ */
+export function isBot(
+  typename: "User" | "Bot",
+  login: string,
+): boolean {
   return typename === "Bot" || login.endsWith("[bot]");
 }


### PR DESCRIPTION
## Summary

Promotes the `isBot` stub from #3 to its canonical form. Rule body and signature unchanged — `isBot(typename, login) → typename === "Bot" || login.endsWith("[bot]")`. The change is documentation polish + truth-table test extension.

## Verification (per the issue spec)

Grepped `src/ingest/*.ts` for `author {` GraphQL fragments. **All author fragments across `src/ingest/issue.ts`, `src/ingest/pull_request.ts`, and `src/ingest/discussion.ts` already include both `... on User { id }` and `... on Bot { id }` inline fragments** — `__typename` is reliably available. No fragment fixes needed.

`isBot()` is the only path that sets `user.is_bot`: `src/ingest/user.ts`'s `upsertUser` writes `is_bot: $is_bot` from the `ParsedUser` it receives, and the parsed value comes from `isBot(__typename, login)` at parse time in each fetcher.

## Test plan

- [x] `bun run typecheck` — clean.
- [x] `bun test` — 57/57 pass across 11 files.
- [x] `bot.test.ts` covers the truth table from #9's spec: `Bot` typename, `[bot]` suffix variants (`dependabot`, `github-actions`, `renovate`), regular user, `Mergify-Bot` (no allowlist → `false`), empty login.
- [ ] `bun run smoke:*` (manual; unaffected).

## Out of scope (deliberately deferred)

- Manual override (`is_bot_override`) — future, only when needed.
- Known-bot allowlist for accounts like `mergify-bot` that don't follow `[bot]` convention — future.
- Re-classification of historical users on rule change — handled naturally by re-upsert on next sync.

Closes #9


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `isBot(typename, login)` the canonical single source of truth for `user.is_bot` with clear JSDoc; behavior unchanged (typename === "Bot" or login ends with "[bot]" → bot). Expands truth‑table tests per #9 to cover github-actions/dependabot/renovate and edge cases like "Mergify-Bot" and empty logins.

<sup>Written for commit b3f63010b27639f953b4992271033c1d5e26bbdc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

