### PR TITLE
feat: label catalog fetcher + replace-all has_label edges

### DIFF
--- a/src/ingest/labels.test.ts
+++ b/src/ingest/labels.test.ts
@@ -1,68 +1,126 @@
-import { describe, it, expect } from "bun:test";
+import { describe, it, expect, mock } from "bun:test";
+import { StringRecordId } from "surrealdb";
 import { withTestDb } from "../test_utils/with_test_db.ts";
-import { upsertLabelsAndEdges } from "./labels.ts";
 import type { ParsedLabel } from "./types.ts";
+
+const catalogPage1 = {
+  repository: {
+    labels: {
+      nodes: [
+        { id: "LBC_1", name: "alpha", color: "ff0000", description: "Alpha label" },
+        { id: "LBC_2", name: "beta", color: "00ff00", description: null },
+      ],
+      pageInfo: { hasNextPage: true, endCursor: "cursor1" },
+    },
+  },
+};
+
+const catalogPage2 = {
+  repository: {
+    labels: {
+      nodes: [
+        { id: "LBC_3", name: "gamma", color: "0000ff", description: "Gamma label" },
+      ],
+      pageInfo: { hasNextPage: false, endCursor: null },
+    },
+  },
+};
+
+mock.module("../clients/github.ts", () => ({
+  paginate: async function* (
+    _query: string,
+    _variables: unknown,
+    selectConnection: (data: unknown) => {
+      nodes: unknown[];
+      pageInfo: { hasNextPage: boolean; endCursor: string | null };
+    },
+  ) {
+    for (const page of [catalogPage1, catalogPage2]) {
+      const connection = selectConnection(page);
+      for (const node of connection.nodes) {
+        yield node;
+      }
+    }
+  },
+  gh: async () => ({}),
+}));
+
+const { upsertLabelsAndEdges, fetchLabelsCatalog, persistLabelCatalog } = await import(
+  "./labels.ts"
+);
 
 const labels: ParsedLabel[] = [
   { github_node_id: "LB_1", name: "bug", color: "d73a4a", description: "Something broken" },
   { github_node_id: "LB_2", name: "enhancement", color: "a2eeef", description: null },
 ];
 
+async function setupIssue(
+  db: Parameters<Parameters<typeof withTestDb>[0]>[0],
+  suffix = "1",
+): Promise<{ issueId: string; repoId: string }> {
+  const [orgRows] = await db.query<[Array<{ id: unknown }>]>(
+    `CREATE org CONTENT {
+      github_node_id: $nid,
+      github_url: "https://github.com/test",
+      login: "test",
+      name: "Test",
+      kind: "User",
+      created_at: time::now(),
+      updated_at: time::now(),
+      deleted_at: NONE
+    }`,
+    { nid: `ORG_${suffix}` },
+  );
+  const orgId = orgRows[0].id;
+
+  const [repoRows] = await db.query<[Array<{ id: unknown }>]>(
+    `CREATE repo CONTENT {
+      github_node_id: $nid,
+      github_url: "https://github.com/test/repo",
+      name: "repo",
+      name_with_owner: "test/repo",
+      description: NONE,
+      is_private: false,
+      owner: $orgId,
+      created_at: time::now(),
+      updated_at: time::now(),
+      deleted_at: NONE
+    }`,
+    { nid: `REPO_${suffix}`, orgId },
+  );
+  const repoId = String(repoRows[0].id);
+
+  const [issueRows] = await db.query<[Array<{ id: unknown }>]>(
+    `CREATE issue CONTENT {
+      github_node_id: $nid,
+      github_url: "https://github.com/test/repo/issues/1",
+      repo: $repoId,
+      number: 1,
+      title: "Test issue",
+      body: NONE,
+      state: "OPEN",
+      state_reason: NONE,
+      author: NONE,
+      closed_at: NONE,
+      created_at: time::now(),
+      updated_at: time::now(),
+      deleted_at: NONE,
+      content_hash: NONE,
+      embedding: NONE
+    }`,
+    { nid: `ISSUE_${suffix}`, repoId: new StringRecordId(repoId) },
+  );
+  const issueId = String(issueRows[0].id);
+
+  return { issueId, repoId };
+}
+
+// ─── 1. upsertLabelsAndEdges basic idempotency ───────────────────────────────
+
 describe("upsertLabelsAndEdges", () => {
   it("creates 2 labels and 2 edges, no duplicates on second call", async () => {
     await withTestDb(async (db) => {
-      const [orgRows] = await db.query<[Array<{ id: unknown }>]>(
-        `CREATE org CONTENT {
-          github_node_id: "ORG_1",
-          github_url: "https://github.com/test",
-          login: "test",
-          name: "Test",
-          kind: "User",
-          created_at: time::now(),
-          updated_at: time::now(),
-          deleted_at: NONE
-        }`,
-      );
-      const orgId = orgRows[0].id;
-
-      const [repoRows] = await db.query<[Array<{ id: unknown }>]>(
-        `CREATE repo CONTENT {
-          github_node_id: "REPO_1",
-          github_url: "https://github.com/test/repo",
-          name: "repo",
-          name_with_owner: "test/repo",
-          description: NONE,
-          is_private: false,
-          owner: $orgId,
-          created_at: time::now(),
-          updated_at: time::now(),
-          deleted_at: NONE
-        }`,
-        { orgId },
-      );
-      const repoId = repoRows[0].id;
-
-      const [issueRows] = await db.query<[Array<{ id: unknown }>]>(
-        `CREATE issue CONTENT {
-          github_node_id: "ISSUE_1",
-          github_url: "https://github.com/test/repo/issues/1",
-          repo: $repoId,
-          number: 1,
-          title: "Test issue",
-          body: NONE,
-          state: "OPEN",
-          state_reason: NONE,
-          author: NONE,
-          closed_at: NONE,
-          created_at: time::now(),
-          updated_at: time::now(),
-          deleted_at: NONE,
-          content_hash: NONE,
-          embedding: NONE
-        }`,
-        { repoId },
-      );
-      const issueId = String(issueRows[0].id);
+      const { issueId } = await setupIssue(db);
 
       await upsertLabelsAndEdges(db, issueId, labels);
 
@@ -77,6 +135,130 @@ describe("upsertLabelsAndEdges", () => {
       const [edgeRows2] = await db.query<[Array<unknown>]>("SELECT id FROM has_label");
       expect(labelRows2.length).toBe(2);
       expect(edgeRows2.length).toBe(2);
+    });
+  });
+});
+
+// ─── 2. Replace-all semantics ─────────────────────────────────────────────────
+
+describe("upsertLabelsAndEdges replace-all semantics", () => {
+  it("after second call with 1 different label, exactly 1 has_label edge remains", async () => {
+    await withTestDb(async (db) => {
+      const { issueId } = await setupIssue(db);
+
+      const threeLabels: ParsedLabel[] = [
+        { github_node_id: "LB_A", name: "alpha", color: "ff0000", description: null },
+        { github_node_id: "LB_B", name: "beta", color: "00ff00", description: null },
+        { github_node_id: "LB_C", name: "gamma", color: "0000ff", description: null },
+      ];
+      await upsertLabelsAndEdges(db, issueId, threeLabels);
+
+      const [edgeRows1] = await db.query<[Array<unknown>]>("SELECT id FROM has_label");
+      expect(edgeRows1.length).toBe(3);
+
+      const oneLabel: ParsedLabel[] = [
+        { github_node_id: "LB_D", name: "delta", color: "ffffff", description: null },
+      ];
+      await upsertLabelsAndEdges(db, issueId, oneLabel);
+
+      const [edgeRows2] = await db.query<[Array<unknown>]>("SELECT id FROM has_label");
+      expect(edgeRows2.length).toBe(1);
+
+      const [oldEdges] = await db.query<[Array<unknown>]>(
+        "SELECT id FROM has_label WHERE out.github_node_id IN ['LB_A', 'LB_B', 'LB_C']",
+      );
+      expect(oldEdges.length).toBe(0);
+    });
+  });
+});
+
+// ─── 3. fetchLabelsCatalog mock ───────────────────────────────────────────────
+
+describe("fetchLabelsCatalog mock", () => {
+  it("yields all labels from both fixture pages with correct ParsedLabel shape", async () => {
+    const results: ParsedLabel[] = [];
+    for await (const label of fetchLabelsCatalog("owner", "repo")) {
+      results.push(label);
+    }
+
+    expect(results.length).toBe(3);
+    expect(results[0]).toEqual({
+      github_node_id: "LBC_1",
+      name: "alpha",
+      color: "ff0000",
+      description: "Alpha label",
+    });
+    expect(results[1]).toEqual({
+      github_node_id: "LBC_2",
+      name: "beta",
+      color: "00ff00",
+      description: null,
+    });
+    expect(results[2]).toEqual({
+      github_node_id: "LBC_3",
+      name: "gamma",
+      color: "0000ff",
+      description: "Gamma label",
+    });
+  });
+});
+
+// ─── 4. persistLabelCatalog idempotency ──────────────────────────────────────
+
+describe("persistLabelCatalog idempotency", () => {
+  it("calling twice with same ParsedLabel produces exactly 1 label row with correct fields", async () => {
+    await withTestDb(async (db) => {
+      const [orgRows] = await db.query<[Array<{ id: unknown }>]>(
+        `CREATE org CONTENT {
+          github_node_id: "ORG_PC",
+          github_url: "https://github.com/pc",
+          login: "pc",
+          name: "PC",
+          kind: "User",
+          created_at: time::now(),
+          updated_at: time::now(),
+          deleted_at: NONE
+        }`,
+      );
+      const orgId = orgRows[0].id;
+
+      const [repoRows] = await db.query<[Array<{ id: unknown }>]>(
+        `CREATE repo CONTENT {
+          github_node_id: "REPO_PC",
+          github_url: "https://github.com/pc/repo",
+          name: "repo",
+          name_with_owner: "pc/repo",
+          description: NONE,
+          is_private: false,
+          owner: $orgId,
+          created_at: time::now(),
+          updated_at: time::now(),
+          deleted_at: NONE
+        }`,
+        { orgId },
+      );
+      const repoId = String(repoRows[0].id);
+      const repo = { id: repoId, name_with_owner: "pc/repo" };
+
+      const parsed: ParsedLabel = {
+        github_node_id: "LBC_IDEM",
+        name: "bug",
+        color: "d73a4a",
+        description: "A bug",
+      };
+
+      await persistLabelCatalog(db, repo, parsed);
+      await persistLabelCatalog(db, repo, parsed);
+
+      const [labelRows] = await db.query<
+        [Array<{ name: string; color: string; repo: unknown }>]
+      >("SELECT name, color, repo FROM label WHERE github_node_id = $id", {
+        id: "LBC_IDEM",
+      });
+      expect(labelRows.length).toBe(1);
+      expect(labelRows[0].name).toBe("bug");
+      expect(labelRows[0].color).toBe("d73a4a");
+      expect(String(labelRows[0].repo)).toBe(repoId);
     });
   });
 });

--- a/src/ingest/labels.ts
+++ b/src/ingest/labels.ts
@@ -1,8 +1,109 @@
+import { z } from "zod";
 import { StringRecordId } from "surrealdb";
 import type { Surreal } from "surrealdb";
-import type { ParsedLabel } from "./types.ts";
+import { paginate } from "../clients/github.ts";
+import type { ParsedLabel, RepoRef } from "./types.ts";
 
-// STUB: refined by #6. Stable signature.
+const LabelNodeSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  color: z.string(),
+  description: z.string().nullable(),
+});
+
+const LABELS_CATALOG_QUERY = `
+  query FetchLabelsCatalog($owner: String!, $name: String!, $cursor: String) {
+    repository(owner: $owner, name: $name) {
+      labels(first: 100, after: $cursor, orderBy: {field: NAME, direction: ASC}) {
+        pageInfo { hasNextPage endCursor }
+        nodes { id name color description }
+      }
+    }
+  }
+`;
+
+export async function* fetchLabelsCatalog(
+  owner: string,
+  name: string,
+): AsyncGenerator<ParsedLabel> {
+  for await (const rawNode of paginate(
+    LABELS_CATALOG_QUERY,
+    { owner, name },
+    (data: unknown) => {
+      const d = data as {
+        repository: {
+          labels: {
+            nodes: unknown[];
+            pageInfo: { hasNextPage: boolean; endCursor: string | null };
+          };
+        };
+      };
+      return d.repository.labels;
+    },
+  )) {
+    const node = LabelNodeSchema.parse(rawNode);
+    yield {
+      github_node_id: node.id,
+      name: node.name,
+      color: node.color,
+      description: node.description,
+    };
+  }
+}
+
+export async function persistLabelCatalog(
+  db: Surreal,
+  repo: RepoRef,
+  parsed: ParsedLabel,
+): Promise<void> {
+  const repoRef = new StringRecordId(repo.id);
+  const descSql = parsed.description === null ? "NONE" : "$description";
+  const descParam = parsed.description !== null ? { description: parsed.description } : {};
+
+  const [existing] = await db.query<[Array<{ id: unknown }>]>(
+    "SELECT id FROM label WHERE github_node_id = $github_node_id",
+    { github_node_id: parsed.github_node_id },
+  );
+
+  if (existing.length === 0) {
+    await db.query(
+      `CREATE label CONTENT {
+        github_node_id: $github_node_id,
+        repo: $repo,
+        name: $name,
+        color: $color,
+        description: ${descSql},
+        created_at: time::now(),
+        updated_at: time::now(),
+        deleted_at: NONE
+      }`,
+      {
+        github_node_id: parsed.github_node_id,
+        repo: repoRef,
+        name: parsed.name,
+        color: parsed.color,
+        ...descParam,
+      },
+    );
+  } else {
+    await db.query(
+      `UPDATE $id SET
+        name = $name,
+        color = $color,
+        description = ${descSql},
+        updated_at = time::now(),
+        repo = $repo`,
+      {
+        id: existing[0].id,
+        name: parsed.name,
+        color: parsed.color,
+        repo: repoRef,
+        ...descParam,
+      },
+    );
+  }
+}
+
 export async function upsertLabelsAndEdges(
   db: Surreal,
   parentRecordId: string,
@@ -17,14 +118,13 @@ export async function upsertLabelsAndEdges(
 
   const repoId = parentRows[0]?.repo;
 
+  const labelIds: unknown[] = [];
   for (const label of labels) {
     const [existing] = await db.query<[Array<{ id: unknown }>]>(
       "SELECT id FROM label WHERE github_node_id = $github_node_id",
       { github_node_id: label.github_node_id },
     );
 
-    // SurrealDB option<string> accepts strings or NONE, not JS null.
-    // Inline NONE as a SQL literal when description is null.
     const descSql = label.description === null ? "NONE" : "$description";
     const descParam = label.description !== null ? { description: label.description } : {};
 
@@ -66,17 +166,15 @@ export async function upsertLabelsAndEdges(
         },
       );
     }
+    labelIds.push(labelId);
+  }
 
-    const [edges] = await db.query<[Array<{ id: unknown }>]>(
-      "SELECT id FROM has_label WHERE in = $parentRef AND out = $labelId",
+  await db.query("DELETE has_label WHERE in = $parentRef", { parentRef });
+
+  for (const labelId of labelIds) {
+    await db.query(
+      "RELATE $parentRef->has_label->$labelId CONTENT { created_at: time::now() }",
       { parentRef, labelId },
     );
-
-    if (edges.length === 0) {
-      await db.query(
-        "RELATE $parentRef->has_label->$labelId CONTENT { created_at: time::now() }",
-        { parentRef, labelId },
-      );
-    }
   }
 }


### PR DESCRIPTION
## Summary

Final implementation of `upsertLabelsAndEdges` (already called by #3, #4, #5 as a stub) plus the new eager catalog functions:
- `fetchLabelsCatalog(owner, name)` — paginated async generator over `Repository.labels`, ordered by NAME ASC for stable iteration.
- `persistLabelCatalog(db, repo, parsed)` — DB-only upsert by `github_node_id`, sets `label.repo` link.

The signature of `upsertLabelsAndEdges(db, parentRecordId, labels)` is unchanged; #3/#4/#5 keep working without modification.

## Edge semantics

Switched to **replace-all** per the `Nodes are historical; edges are relational truth` principle in `ARCHITECTURE.md`:
1. Upsert each label by `github_node_id` (collect record ids).
2. Hard-delete all existing `has_label` edges originating at the parent.
3. Re-create one `has_label` edge per label in the payload.

Net effect: when a label is removed upstream, the local edge disappears on the next persist. The label node itself stays (node soft-delete; reconciliation in future #15).

## Test plan

- [x] `bun run typecheck` — clean.
- [x] `bun test` — 60/60 pass across 11 files (catalog idempotency, replace-all semantics, edge dedup all covered).
- [x] Replace-all verified: persist 3 labels → 3 edges; persist 1 different label → 1 edge, the original 3 are gone, but the original 3 label *nodes* still exist (un-tombstoned).
- [x] `label.repo` link set on every persisted label, both via catalog and via inline upsert.
- [ ] `bun run smoke:*` (manual; unaffected).

## Out of scope

- Removed-label tombstoning at the node level (#15, future).
- Label search by name across repos (no consumer in milestone 1).
- Embedding labels.

Closes #6


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a label catalog fetcher and DB persistence, and switches `has_label` edges to replace-all so relations mirror GitHub on every persist. Finalizes `upsertLabelsAndEdges` without changing its signature; existing callers keep working.

- **New Features**
  - `fetchLabelsCatalog(owner, name)`: paginated async generator over repo labels, ordered by name.
  - `persistLabelCatalog(db, repo, parsed)`: upserts by `github_node_id` and sets `label.repo`.
  - `upsertLabelsAndEdges(db, parentRecordId, labels)`: now deletes all existing `has_label` edges from the parent and recreates one per label to reflect removals.

<sup>Written for commit 3c8d3c7a79e58cf645d7c300e0a885ff581df2fe. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

