### PR TITLE
feat: comment fetcher (issues/PRs/discussions) + reply threading

### DIFF
--- a/schemas.surrealql
+++ b/schemas.surrealql
@@ -162,6 +162,7 @@ DEFINE FIELD IF NOT EXISTS github_url        ON TABLE comment TYPE string;
 DEFINE FIELD IF NOT EXISTS parent_issue      ON TABLE comment TYPE option<record<issue>>;
 DEFINE FIELD IF NOT EXISTS parent_pr         ON TABLE comment TYPE option<record<pull_request>>;
 DEFINE FIELD IF NOT EXISTS parent_discussion ON TABLE comment TYPE option<record<discussion>>;
+DEFINE FIELD IF NOT EXISTS parent_comment    ON TABLE comment TYPE option<record<comment>>;
 DEFINE FIELD IF NOT EXISTS author            ON TABLE comment TYPE option<record<user>>;
 DEFINE FIELD IF NOT EXISTS body              ON TABLE comment TYPE string;
 DEFINE FIELD IF NOT EXISTS created_at        ON TABLE comment TYPE datetime;

--- a/src/ingest/__fixtures__/comments_discussion_page_1.json
+++ b/src/ingest/__fixtures__/comments_discussion_page_1.json
@@ -1,0 +1,43 @@
+{
+  "repository": {
+    "discussion": {
+      "id": "D_TEST_001",
+      "comments": {
+        "pageInfo": { "hasNextPage": false, "endCursor": null },
+        "nodes": [
+          {
+            "id": "DC_001",
+            "url": "https://github.com/test/repo/discussions/1#discussioncomment-1",
+            "body": "Top-level discussion comment",
+            "createdAt": "2026-01-01T10:00:00Z",
+            "updatedAt": "2026-01-01T10:00:00Z",
+            "author": {
+              "__typename": "User",
+              "id": "U_001",
+              "login": "testuser",
+              "url": "https://github.com/testuser"
+            },
+            "replies": {
+              "pageInfo": { "hasNextPage": false, "endCursor": null },
+              "nodes": [
+                {
+                  "id": "DC_REPLY_001",
+                  "url": "https://github.com/test/repo/discussions/1#discussioncomment-2",
+                  "body": "Reply to top-level comment",
+                  "createdAt": "2026-01-01T11:00:00Z",
+                  "updatedAt": "2026-01-01T11:00:00Z",
+                  "author": {
+                    "__typename": "User",
+                    "id": "U_002",
+                    "login": "replyuser",
+                    "url": "https://github.com/replyuser"
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/ingest/__fixtures__/comments_issue_page_1.json
+++ b/src/ingest/__fixtures__/comments_issue_page_1.json
@@ -1,0 +1,33 @@
+{
+  "repository": {
+    "issue": {
+      "id": "I_TEST_001",
+      "comments": {
+        "pageInfo": { "hasNextPage": false, "endCursor": null },
+        "nodes": [
+          {
+            "id": "IC_001",
+            "url": "https://github.com/test/repo/issues/1#issuecomment-1",
+            "body": "First issue comment\r\nwith CRLF",
+            "createdAt": "2026-01-01T10:00:00Z",
+            "updatedAt": "2026-01-01T10:00:00Z",
+            "author": {
+              "__typename": "User",
+              "id": "U_001",
+              "login": "testuser",
+              "url": "https://github.com/testuser"
+            }
+          },
+          {
+            "id": "IC_002",
+            "url": "https://github.com/test/repo/issues/1#issuecomment-2",
+            "body": null,
+            "createdAt": "2026-01-02T10:00:00Z",
+            "updatedAt": "2026-01-02T10:00:00Z",
+            "author": null
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/ingest/__fixtures__/comments_pr_page_1.json
+++ b/src/ingest/__fixtures__/comments_pr_page_1.json
@@ -1,0 +1,33 @@
+{
+  "repository": {
+    "pullRequest": {
+      "id": "PR_TEST_001",
+      "comments": {
+        "pageInfo": { "hasNextPage": false, "endCursor": null },
+        "nodes": [
+          {
+            "id": "PRC_001",
+            "url": "https://github.com/test/repo/pull/1#issuecomment-100",
+            "body": "First PR comment",
+            "createdAt": "2026-01-01T10:00:00Z",
+            "updatedAt": "2026-01-01T10:00:00Z",
+            "author": {
+              "__typename": "User",
+              "id": "U_001",
+              "login": "testuser",
+              "url": "https://github.com/testuser"
+            }
+          },
+          {
+            "id": "PRC_002",
+            "url": "https://github.com/test/repo/pull/1#issuecomment-101",
+            "body": null,
+            "createdAt": "2026-01-02T10:00:00Z",
+            "updatedAt": "2026-01-02T10:00:00Z",
+            "author": null
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/ingest/comment.test.ts
+++ b/src/ingest/comment.test.ts
@@ -1,0 +1,468 @@
+import { describe, it, expect, mock } from "bun:test";
+import { StringRecordId } from "surrealdb";
+import { withTestDb } from "../test_utils/with_test_db.ts";
+
+import issueFixture from "./__fixtures__/comments_issue_page_1.json";
+import discussionFixture from "./__fixtures__/comments_discussion_page_1.json";
+
+let currentFixture: unknown = issueFixture;
+
+mock.module("../clients/github.ts", () => ({
+  paginate: async function* (
+    _query: string,
+    _variables: unknown,
+    selectConnection: (data: unknown) => {
+      nodes: unknown[];
+      pageInfo: { hasNextPage: boolean; endCursor: string | null };
+    },
+  ) {
+    const connection = selectConnection(currentFixture);
+    for (const node of connection.nodes) {
+      yield node;
+    }
+  },
+  gh: async () => ({}),
+}));
+
+const {
+  persistComment,
+  tombstoneMissingComments,
+  hashBody,
+  fetchCommentsForIssue,
+  fetchCommentsForDiscussion,
+} = await import("./comment.ts");
+type ParsedComment = Parameters<typeof persistComment>[1];
+
+// ─── shared setup helpers ─────────────────────────────────────────────────────
+
+type Db = Parameters<Parameters<typeof withTestDb>[0]>[0];
+
+async function setupRepo(db: Db, suffix: string): Promise<string> {
+  const [orgRows] = await db.query<[Array<{ id: unknown }>]>(
+    `CREATE org CONTENT {
+      github_node_id: $nid,
+      github_url: $url,
+      login: $login,
+      name: $name,
+      kind: "User",
+      created_at: time::now(),
+      updated_at: time::now(),
+      deleted_at: NONE
+    }`,
+    {
+      nid: `ORG_${suffix}`,
+      url: `https://github.com/org${suffix}`,
+      login: `org${suffix}`,
+      name: `Org ${suffix}`,
+    },
+  );
+  const orgId = orgRows[0].id;
+
+  const [repoRows] = await db.query<[Array<{ id: unknown }>]>(
+    `CREATE repo CONTENT {
+      github_node_id: $nid,
+      github_url: $url,
+      name: "repo",
+      name_with_owner: $nwo,
+      description: NONE,
+      is_private: false,
+      owner: $orgId,
+      created_at: time::now(),
+      updated_at: time::now(),
+      deleted_at: NONE
+    }`,
+    {
+      nid: `REPO_${suffix}`,
+      url: `https://github.com/org${suffix}/repo`,
+      nwo: `org${suffix}/repo`,
+      orgId,
+    },
+  );
+  return String(repoRows[0].id);
+}
+
+async function setupIssue(db: Db, repoId: string, nodeId: string): Promise<string> {
+  const [rows] = await db.query<[Array<{ id: unknown }>]>(
+    `CREATE issue CONTENT {
+      github_node_id: $nid,
+      github_url: "https://github.com/test/repo/issues/1",
+      repo: $repo,
+      number: 1,
+      title: "Test Issue",
+      body: NONE,
+      state: "OPEN",
+      state_reason: NONE,
+      author: NONE,
+      closed_at: NONE,
+      created_at: time::now(),
+      updated_at: time::now(),
+      deleted_at: NONE,
+      content_hash: NONE,
+      embedding: NONE
+    }`,
+    { nid: nodeId, repo: new StringRecordId(repoId) },
+  );
+  return String(rows[0].id);
+}
+
+async function setupPR(db: Db, repoId: string, nodeId: string): Promise<string> {
+  const [rows] = await db.query<[Array<{ id: unknown }>]>(
+    `CREATE pull_request CONTENT {
+      github_node_id: $nid,
+      github_url: "https://github.com/test/repo/pull/1",
+      repo: $repo,
+      number: 1,
+      title: "Test PR",
+      body: NONE,
+      state: "OPEN",
+      author: NONE,
+      merged_at: NONE,
+      closed_at: NONE,
+      created_at: time::now(),
+      updated_at: time::now(),
+      deleted_at: NONE,
+      content_hash: NONE,
+      embedding: NONE
+    }`,
+    { nid: nodeId, repo: new StringRecordId(repoId) },
+  );
+  return String(rows[0].id);
+}
+
+async function setupDiscussion(db: Db, repoId: string, nodeId: string): Promise<string> {
+  const [rows] = await db.query<[Array<{ id: unknown }>]>(
+    `CREATE discussion CONTENT {
+      github_node_id: $nid,
+      github_url: "https://github.com/test/repo/discussions/1",
+      repo: $repo,
+      number: 1,
+      title: "Test Discussion",
+      body: NONE,
+      category: NONE,
+      author: NONE,
+      answer_chosen_at: NONE,
+      created_at: time::now(),
+      updated_at: time::now(),
+      deleted_at: NONE,
+      content_hash: NONE,
+      embedding: NONE
+    }`,
+    { nid: nodeId, repo: new StringRecordId(repoId) },
+  );
+  return String(rows[0].id);
+}
+
+function makeComment(
+  overrides: Partial<ParsedComment> & {
+    parent_kind: ParsedComment["parent_kind"];
+    parent_node_id: string;
+  },
+): ParsedComment {
+  return {
+    github_node_id: "C_TEST_001",
+    github_url: "https://github.com/test/repo/issues/1#issuecomment-1",
+    body: "Test comment body",
+    created_at: new Date("2026-01-01T00:00:00Z"),
+    updated_at: new Date("2026-01-01T00:00:00Z"),
+    content_hash: hashBody("Test comment body"),
+    author: {
+      github_node_id: "U_TEST_001",
+      login: "commenter",
+      is_bot: false,
+      github_url: "https://github.com/commenter",
+    },
+    parent_comment_node_id: null,
+    ...overrides,
+  };
+}
+
+// ─── 1. persistComment for issue parent ──────────────────────────────────────
+
+describe("persistComment for issue parent", () => {
+  it("sets parent_issue, and parent_pr/parent_discussion are NONE", async () => {
+    await withTestDb(async (db) => {
+      const repoId = await setupRepo(db, "CA");
+      await setupIssue(db, repoId, "I_CA_001");
+
+      const comment = makeComment({ parent_kind: "issue", parent_node_id: "I_CA_001" });
+      await persistComment(db, comment);
+
+      const [rows] = await db.query<
+        [Array<{ pi_none: boolean; ppr_none: boolean; pd_none: boolean }>]
+      >(
+        `SELECT
+          parent_issue IS NONE AS pi_none,
+          parent_pr IS NONE AS ppr_none,
+          parent_discussion IS NONE AS pd_none
+        FROM comment WHERE github_node_id = $id`,
+        { id: comment.github_node_id },
+      );
+      expect(rows.length).toBe(1);
+      expect(rows[0].pi_none).toBe(false);
+      expect(rows[0].ppr_none).toBe(true);
+      expect(rows[0].pd_none).toBe(true);
+    });
+  });
+});
+
+// ─── 2. persistComment for PR parent ─────────────────────────────────────────
+
+describe("persistComment for PR parent", () => {
+  it("sets parent_pr, and parent_issue/parent_discussion are NONE", async () => {
+    await withTestDb(async (db) => {
+      const repoId = await setupRepo(db, "CB");
+      await setupPR(db, repoId, "PR_CB_001");
+
+      const comment = makeComment({
+        github_node_id: "C_CB_001",
+        parent_kind: "pull_request",
+        parent_node_id: "PR_CB_001",
+      });
+      await persistComment(db, comment);
+
+      const [rows] = await db.query<
+        [Array<{ pi_none: boolean; ppr_none: boolean; pd_none: boolean }>]
+      >(
+        `SELECT
+          parent_issue IS NONE AS pi_none,
+          parent_pr IS NONE AS ppr_none,
+          parent_discussion IS NONE AS pd_none
+        FROM comment WHERE github_node_id = $id`,
+        { id: comment.github_node_id },
+      );
+      expect(rows.length).toBe(1);
+      expect(rows[0].pi_none).toBe(true);
+      expect(rows[0].ppr_none).toBe(false);
+      expect(rows[0].pd_none).toBe(true);
+    });
+  });
+});
+
+// ─── 3. persistComment for discussion parent ──────────────────────────────────
+
+describe("persistComment for discussion parent", () => {
+  it("sets parent_discussion, and parent_issue/parent_pr are NONE", async () => {
+    await withTestDb(async (db) => {
+      const repoId = await setupRepo(db, "CC");
+      await setupDiscussion(db, repoId, "D_CC_001");
+
+      const comment = makeComment({
+        github_node_id: "C_CC_001",
+        parent_kind: "discussion",
+        parent_node_id: "D_CC_001",
+      });
+      await persistComment(db, comment);
+
+      const [rows] = await db.query<
+        [Array<{ pi_none: boolean; ppr_none: boolean; pd_none: boolean }>]
+      >(
+        `SELECT
+          parent_issue IS NONE AS pi_none,
+          parent_pr IS NONE AS ppr_none,
+          parent_discussion IS NONE AS pd_none
+        FROM comment WHERE github_node_id = $id`,
+        { id: comment.github_node_id },
+      );
+      expect(rows.length).toBe(1);
+      expect(rows[0].pi_none).toBe(true);
+      expect(rows[0].ppr_none).toBe(true);
+      expect(rows[0].pd_none).toBe(false);
+    });
+  });
+});
+
+// ─── 4. persistComment idempotency ────────────────────────────────────────────
+
+describe("persistComment idempotency", () => {
+  it("persisting same comment twice leaves exactly 1 comment row and 1 user row", async () => {
+    await withTestDb(async (db) => {
+      const repoId = await setupRepo(db, "CD");
+      await setupIssue(db, repoId, "I_CD_001");
+
+      const comment = makeComment({ parent_kind: "issue", parent_node_id: "I_CD_001" });
+      await persistComment(db, comment);
+      await persistComment(db, comment);
+
+      const [commentRows] = await db.query<[Array<unknown>]>("SELECT id FROM comment");
+      expect(commentRows.length).toBe(1);
+
+      const [userRows] = await db.query<[Array<unknown>]>("SELECT id FROM user");
+      expect(userRows.length).toBe(1);
+    });
+  });
+});
+
+// ─── 5. persistComment author: null ──────────────────────────────────────────
+
+describe("persistComment author: null", () => {
+  it("stores author as NONE and creates no user rows", async () => {
+    await withTestDb(async (db) => {
+      const repoId = await setupRepo(db, "CE");
+      await setupIssue(db, repoId, "I_CE_001");
+
+      const comment = makeComment({
+        github_node_id: "C_CE_001",
+        parent_kind: "issue",
+        parent_node_id: "I_CE_001",
+        author: null,
+      });
+      await persistComment(db, comment);
+
+      const [rows] = await db.query<[Array<{ is_none: boolean }>]>(
+        "SELECT author IS NONE AS is_none FROM comment WHERE github_node_id = $id",
+        { id: comment.github_node_id },
+      );
+      expect(rows.length).toBe(1);
+      expect(rows[0].is_none).toBe(true);
+
+      const [userRows] = await db.query<[Array<unknown>]>("SELECT id FROM user");
+      expect(userRows.length).toBe(0);
+    });
+  });
+});
+
+// ─── 6. persistComment parent not found ──────────────────────────────────────
+
+describe("persistComment parent not found", () => {
+  it("throws an error matching 'parent not found' when parent does not exist", async () => {
+    await withTestDb(async (db) => {
+      const comment = makeComment({
+        parent_kind: "issue",
+        parent_node_id: "I_NONEXISTENT",
+      });
+
+      await expect(persistComment(db, comment)).rejects.toThrow("parent not found");
+    });
+  });
+});
+
+// ─── 7. persistComment discussion reply ──────────────────────────────────────
+
+describe("persistComment discussion reply", () => {
+  it("reply's parent_comment field points to the top-level comment", async () => {
+    await withTestDb(async (db) => {
+      const repoId = await setupRepo(db, "CF");
+      await setupDiscussion(db, repoId, "D_CF_001");
+
+      const topComment = makeComment({
+        github_node_id: "C_CF_TOP",
+        parent_kind: "discussion",
+        parent_node_id: "D_CF_001",
+      });
+      await persistComment(db, topComment);
+
+      const reply = makeComment({
+        github_node_id: "C_CF_REPLY",
+        parent_kind: "discussion",
+        parent_node_id: "D_CF_001",
+        parent_comment_node_id: "C_CF_TOP",
+      });
+      await persistComment(db, reply);
+
+      const [rows] = await db.query<[Array<{ pc_none: boolean }>]>(
+        "SELECT parent_comment IS NONE AS pc_none FROM comment WHERE github_node_id = $id",
+        { id: reply.github_node_id },
+      );
+      expect(rows.length).toBe(1);
+      expect(rows[0].pc_none).toBe(false);
+    });
+  });
+});
+
+// ─── 8. tombstoneMissingComments ─────────────────────────────────────────────
+
+describe("tombstoneMissingComments", () => {
+  it("marks absent comment with deleted_at and returns { tombstoned: 1 }", async () => {
+    await withTestDb(async (db) => {
+      const repoId = await setupRepo(db, "CG");
+      await setupIssue(db, repoId, "I_CG_001");
+
+      const c1 = makeComment({
+        github_node_id: "C_CG_001",
+        parent_kind: "issue",
+        parent_node_id: "I_CG_001",
+        author: null,
+      });
+      const c2 = makeComment({
+        github_node_id: "C_CG_002",
+        parent_kind: "issue",
+        parent_node_id: "I_CG_001",
+        author: null,
+      });
+      await persistComment(db, c1);
+      await persistComment(db, c2);
+
+      const result = await tombstoneMissingComments(db, "I_CG_001", "issue", ["C_CG_001"]);
+      expect(result).toEqual({ tombstoned: 1 });
+
+      const [kept] = await db.query<[Array<{ is_none: boolean }>]>(
+        "SELECT deleted_at IS NONE AS is_none FROM comment WHERE github_node_id = $id",
+        { id: "C_CG_001" },
+      );
+      expect(kept[0].is_none).toBe(true);
+
+      const [gone] = await db.query<[Array<{ is_none: boolean }>]>(
+        "SELECT deleted_at IS NONE AS is_none FROM comment WHERE github_node_id = $id",
+        { id: "C_CG_002" },
+      );
+      expect(gone[0].is_none).toBe(false);
+    });
+  });
+});
+
+// ─── 9. fetchCommentsForIssue mock ───────────────────────────────────────────
+
+describe("fetchCommentsForIssue mock", () => {
+  it("yields 2 comments with correct shape from fixture", async () => {
+    currentFixture = issueFixture;
+
+    const comments: ParsedComment[] = [];
+    for await (const c of fetchCommentsForIssue("test", "repo", 1)) {
+      comments.push(c);
+    }
+
+    expect(comments.length).toBe(2);
+
+    for (const c of comments) {
+      expect(c.parent_kind).toBe("issue");
+      expect(c.content_hash).toMatch(/^[0-9a-f]{64}$/);
+      expect(c.parent_comment_node_id).toBeNull();
+    }
+
+    const c1 = comments.find((c) => c.github_node_id === "IC_001")!;
+    expect(c1).toBeDefined();
+    expect(c1.author).not.toBeNull();
+    expect(c1.author?.login).toBe("testuser");
+    expect(c1.body).not.toContain("\r\n");
+
+    const c2 = comments.find((c) => c.github_node_id === "IC_002")!;
+    expect(c2).toBeDefined();
+    expect(c2.author).toBeNull();
+  });
+});
+
+// ─── 10. fetchCommentsForDiscussion mock ─────────────────────────────────────
+
+describe("fetchCommentsForDiscussion mock", () => {
+  it("yields top-level comment and reply; reply has parent_comment_node_id set", async () => {
+    currentFixture = discussionFixture;
+
+    const comments: ParsedComment[] = [];
+    for await (const c of fetchCommentsForDiscussion("test", "repo", 1)) {
+      comments.push(c);
+    }
+
+    expect(comments.length).toBe(2);
+
+    const top = comments.find((c) => c.github_node_id === "DC_001")!;
+    expect(top).toBeDefined();
+    expect(top.parent_kind).toBe("discussion");
+    expect(top.parent_comment_node_id).toBeNull();
+
+    const reply = comments.find((c) => c.github_node_id === "DC_REPLY_001")!;
+    expect(reply).toBeDefined();
+    expect(reply.parent_kind).toBe("discussion");
+    expect(reply.parent_comment_node_id).toBe("DC_001");
+    expect(reply.author?.login).toBe("replyuser");
+  });
+});

--- a/src/ingest/comment.ts
+++ b/src/ingest/comment.ts
@@ -1,0 +1,462 @@
+import { createHash } from "node:crypto";
+import { z } from "zod";
+import { StringRecordId } from "surrealdb";
+import type { Surreal } from "surrealdb";
+import { paginate, gh } from "../clients/github.ts";
+import { isBot } from "./bot.ts";
+import { upsertUser } from "./user.ts";
+import type { ParsedUser } from "./types.ts";
+
+export type ParsedComment = {
+  github_node_id: string;
+  github_url: string;
+  body: string;
+  created_at: Date;
+  updated_at: Date;
+  content_hash: string;
+  author: ParsedUser | null;
+  parent_kind: "issue" | "pull_request" | "discussion";
+  parent_node_id: string;
+  parent_comment_node_id: string | null;
+};
+
+export function hashBody(rawBody: string | null): string {
+  const normalizedBody = (rawBody ?? "").replace(/\r\n/g, "\n");
+  return createHash("sha256").update(normalizedBody).digest("hex");
+}
+
+const AuthorSchema = z
+  .object({
+    __typename: z.string(),
+    id: z.string().optional(),
+    login: z.string(),
+    url: z.string(),
+  })
+  .nullable();
+
+const CommentNodeSchema = z.object({
+  id: z.string(),
+  url: z.string(),
+  body: z.string().nullable(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+  author: AuthorSchema,
+});
+
+const ReplyConnectionSchema = z.object({
+  pageInfo: z.object({
+    hasNextPage: z.boolean(),
+    endCursor: z.string().nullable(),
+  }),
+  nodes: z.array(CommentNodeSchema),
+});
+
+const DiscussionCommentNodeSchema = CommentNodeSchema.extend({
+  replies: ReplyConnectionSchema,
+});
+
+function parseAuthor(raw: z.infer<typeof AuthorSchema>): ParsedUser | null {
+  if (raw === null) return null;
+  const { __typename, id, login, url: github_url } = raw;
+  if ((__typename === "User" || __typename === "Bot") && id !== undefined) {
+    return {
+      github_node_id: id,
+      login,
+      is_bot: isBot(__typename, login),
+      github_url,
+    };
+  }
+  return null;
+}
+
+const ISSUE_COMMENTS_QUERY = `
+  query FetchIssueComments($owner: String!, $name: String!, $issueNumber: Int!, $cursor: String) {
+    repository(owner: $owner, name: $name) {
+      issue(number: $issueNumber) {
+        id
+        comments(first: 100, after: $cursor) {
+          pageInfo { hasNextPage endCursor }
+          nodes {
+            id url body createdAt updatedAt
+            author {
+              __typename login url
+              ... on User { id }
+              ... on Bot { id }
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+
+const PR_COMMENTS_QUERY = `
+  query FetchPRComments($owner: String!, $name: String!, $prNumber: Int!, $cursor: String) {
+    repository(owner: $owner, name: $name) {
+      pullRequest(number: $prNumber) {
+        id
+        comments(first: 100, after: $cursor) {
+          pageInfo { hasNextPage endCursor }
+          nodes {
+            id url body createdAt updatedAt
+            author {
+              __typename login url
+              ... on User { id }
+              ... on Bot { id }
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+
+const DISCUSSION_COMMENTS_QUERY = `
+  query FetchDiscussionComments($owner: String!, $name: String!, $discussionNumber: Int!, $cursor: String) {
+    repository(owner: $owner, name: $name) {
+      discussion(number: $discussionNumber) {
+        id
+        comments(first: 100, after: $cursor) {
+          pageInfo { hasNextPage endCursor }
+          nodes {
+            id url body createdAt updatedAt
+            author {
+              __typename login url
+              ... on User { id }
+              ... on Bot { id }
+            }
+            replies(first: 100) {
+              pageInfo { hasNextPage endCursor }
+              nodes {
+                id url body createdAt updatedAt
+                author {
+                  __typename login url
+                  ... on User { id }
+                  ... on Bot { id }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+
+const DISCUSSION_COMMENT_REPLIES_QUERY = `
+  query FetchDiscussionCommentReplies($nodeId: ID!, $cursor: String) {
+    node(id: $nodeId) {
+      ... on DiscussionComment {
+        replies(first: 100, after: $cursor) {
+          pageInfo { hasNextPage endCursor }
+          nodes {
+            id url body createdAt updatedAt
+            author {
+              __typename login url
+              ... on User { id }
+              ... on Bot { id }
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+
+export async function* fetchCommentsForIssue(
+  owner: string,
+  name: string,
+  issueNumber: number,
+): AsyncGenerator<ParsedComment> {
+  let parentNodeId = "";
+  for await (const rawNode of paginate(
+    ISSUE_COMMENTS_QUERY,
+    { owner, name, issueNumber },
+    (data: unknown) => {
+      const d = data as {
+        repository: {
+          issue: {
+            id: string;
+            comments: {
+              nodes: unknown[];
+              pageInfo: { hasNextPage: boolean; endCursor: string | null };
+            };
+          };
+        };
+      };
+      parentNodeId = d.repository.issue.id;
+      return d.repository.issue.comments;
+    },
+  )) {
+    const node = CommentNodeSchema.parse(rawNode);
+    yield {
+      github_node_id: node.id,
+      github_url: node.url,
+      body: (node.body ?? "").replace(/\r\n/g, "\n"),
+      created_at: new Date(node.createdAt),
+      updated_at: new Date(node.updatedAt),
+      content_hash: hashBody(node.body),
+      author: parseAuthor(node.author),
+      parent_kind: "issue",
+      parent_node_id: parentNodeId,
+      parent_comment_node_id: null,
+    };
+  }
+}
+
+export async function* fetchCommentsForPullRequest(
+  owner: string,
+  name: string,
+  prNumber: number,
+): AsyncGenerator<ParsedComment> {
+  let parentNodeId = "";
+  for await (const rawNode of paginate(
+    PR_COMMENTS_QUERY,
+    { owner, name, prNumber },
+    (data: unknown) => {
+      const d = data as {
+        repository: {
+          pullRequest: {
+            id: string;
+            comments: {
+              nodes: unknown[];
+              pageInfo: { hasNextPage: boolean; endCursor: string | null };
+            };
+          };
+        };
+      };
+      parentNodeId = d.repository.pullRequest.id;
+      return d.repository.pullRequest.comments;
+    },
+  )) {
+    const node = CommentNodeSchema.parse(rawNode);
+    yield {
+      github_node_id: node.id,
+      github_url: node.url,
+      body: (node.body ?? "").replace(/\r\n/g, "\n"),
+      created_at: new Date(node.createdAt),
+      updated_at: new Date(node.updatedAt),
+      content_hash: hashBody(node.body),
+      author: parseAuthor(node.author),
+      parent_kind: "pull_request",
+      parent_node_id: parentNodeId,
+      parent_comment_node_id: null,
+    };
+  }
+}
+
+export async function* fetchCommentsForDiscussion(
+  owner: string,
+  name: string,
+  discussionNumber: number,
+): AsyncGenerator<ParsedComment> {
+  let parentNodeId = "";
+  for await (const rawNode of paginate(
+    DISCUSSION_COMMENTS_QUERY,
+    { owner, name, discussionNumber },
+    (data: unknown) => {
+      const d = data as {
+        repository: {
+          discussion: {
+            id: string;
+            comments: {
+              nodes: unknown[];
+              pageInfo: { hasNextPage: boolean; endCursor: string | null };
+            };
+          };
+        };
+      };
+      parentNodeId = d.repository.discussion.id;
+      return d.repository.discussion.comments;
+    },
+  )) {
+    const node = DiscussionCommentNodeSchema.parse(rawNode);
+
+    yield {
+      github_node_id: node.id,
+      github_url: node.url,
+      body: (node.body ?? "").replace(/\r\n/g, "\n"),
+      created_at: new Date(node.createdAt),
+      updated_at: new Date(node.updatedAt),
+      content_hash: hashBody(node.body),
+      author: parseAuthor(node.author),
+      parent_kind: "discussion",
+      parent_node_id: parentNodeId,
+      parent_comment_node_id: null,
+    };
+
+    let replyNodes = node.replies.nodes;
+    let replyPageInfo = node.replies.pageInfo;
+
+    while (replyPageInfo.hasNextPage) {
+      const moreData = await gh<unknown>(DISCUSSION_COMMENT_REPLIES_QUERY, {
+        nodeId: node.id,
+        cursor: replyPageInfo.endCursor,
+      });
+      const moreConn = ReplyConnectionSchema.parse(
+        (moreData as { node: { replies: unknown } }).node.replies,
+      );
+      replyNodes = [...replyNodes, ...moreConn.nodes];
+      replyPageInfo = moreConn.pageInfo;
+    }
+
+    for (const reply of replyNodes) {
+      yield {
+        github_node_id: reply.id,
+        github_url: reply.url,
+        body: (reply.body ?? "").replace(/\r\n/g, "\n"),
+        created_at: new Date(reply.createdAt),
+        updated_at: new Date(reply.updatedAt),
+        content_hash: hashBody(reply.body),
+        author: parseAuthor(reply.author),
+        parent_kind: "discussion",
+        parent_node_id: parentNodeId,
+        parent_comment_node_id: node.id,
+      };
+    }
+  }
+}
+
+export async function persistComment(db: Surreal, parsed: ParsedComment): Promise<void> {
+  const parentTable =
+    parsed.parent_kind === "pull_request"
+      ? "pull_request"
+      : parsed.parent_kind === "issue"
+        ? "issue"
+        : "discussion";
+
+  const [parentRows] = await db.query<[Array<{ id: unknown }>]>(
+    `SELECT id FROM ${parentTable} WHERE github_node_id = $node_id`,
+    { node_id: parsed.parent_node_id },
+  );
+  if (parentRows.length === 0) {
+    throw new Error(`parent not found: ${parsed.parent_node_id}`);
+  }
+  const parentRef = new StringRecordId(String(parentRows[0].id));
+
+  let parentCommentRef: StringRecordId | undefined;
+  if (parsed.parent_comment_node_id !== null) {
+    const [pcRows] = await db.query<[Array<{ id: unknown }>]>(
+      "SELECT id FROM comment WHERE github_node_id = $node_id",
+      { node_id: parsed.parent_comment_node_id },
+    );
+    if (pcRows.length === 0) {
+      throw new Error(`parent not found: ${parsed.parent_comment_node_id}`);
+    }
+    parentCommentRef = new StringRecordId(String(pcRows[0].id));
+  }
+
+  let authorRef: StringRecordId | undefined;
+  if (parsed.author !== null) {
+    const id = await upsertUser(db, parsed.author);
+    authorRef = new StringRecordId(id);
+  }
+
+  const authorSql = parsed.author !== null ? "$author" : "NONE";
+  const parentIssueSql = parsed.parent_kind === "issue" ? "$parent_issue" : "NONE";
+  const parentPrSql = parsed.parent_kind === "pull_request" ? "$parent_pr" : "NONE";
+  const parentDiscussionSql = parsed.parent_kind === "discussion" ? "$parent_discussion" : "NONE";
+  const parentCommentSql = parsed.parent_comment_node_id !== null ? "$parent_comment" : "NONE";
+
+  const [existing] = await db.query<[Array<{ id: unknown }>]>(
+    "SELECT id FROM comment WHERE github_node_id = $github_node_id",
+    { github_node_id: parsed.github_node_id },
+  );
+
+  if (existing.length === 0) {
+    await db.query(
+      `CREATE comment CONTENT {
+        github_node_id: $github_node_id,
+        github_url: $github_url,
+        parent_issue: ${parentIssueSql},
+        parent_pr: ${parentPrSql},
+        parent_discussion: ${parentDiscussionSql},
+        parent_comment: ${parentCommentSql},
+        author: ${authorSql},
+        body: $body,
+        created_at: $created_at,
+        updated_at: $updated_at,
+        deleted_at: NONE,
+        content_hash: $content_hash,
+        embedding: NONE
+      }`,
+      {
+        github_node_id: parsed.github_node_id,
+        github_url: parsed.github_url,
+        ...(parsed.parent_kind === "issue" ? { parent_issue: parentRef } : {}),
+        ...(parsed.parent_kind === "pull_request" ? { parent_pr: parentRef } : {}),
+        ...(parsed.parent_kind === "discussion" ? { parent_discussion: parentRef } : {}),
+        ...(parsed.parent_comment_node_id !== null ? { parent_comment: parentCommentRef } : {}),
+        ...(parsed.author !== null ? { author: authorRef } : {}),
+        body: parsed.body,
+        created_at: parsed.created_at,
+        updated_at: parsed.updated_at,
+        content_hash: parsed.content_hash,
+      },
+    );
+  } else {
+    await db.query(
+      `UPDATE $id SET
+        github_url = $github_url,
+        parent_issue = ${parentIssueSql},
+        parent_pr = ${parentPrSql},
+        parent_discussion = ${parentDiscussionSql},
+        parent_comment = ${parentCommentSql},
+        author = ${authorSql},
+        body = $body,
+        updated_at = $updated_at,
+        content_hash = $content_hash`,
+      {
+        id: new StringRecordId(String(existing[0].id)),
+        github_url: parsed.github_url,
+        ...(parsed.parent_kind === "issue" ? { parent_issue: parentRef } : {}),
+        ...(parsed.parent_kind === "pull_request" ? { parent_pr: parentRef } : {}),
+        ...(parsed.parent_kind === "discussion" ? { parent_discussion: parentRef } : {}),
+        ...(parsed.parent_comment_node_id !== null ? { parent_comment: parentCommentRef } : {}),
+        ...(parsed.author !== null ? { author: authorRef } : {}),
+        body: parsed.body,
+        updated_at: parsed.updated_at,
+        content_hash: parsed.content_hash,
+      },
+    );
+  }
+}
+
+export async function tombstoneMissingComments(
+  db: Surreal,
+  parentNodeId: string,
+  parentKind: "issue" | "pull_request" | "discussion",
+  remoteCommentNodeIds: string[],
+): Promise<{ tombstoned: number }> {
+  const parentTable = parentKind === "pull_request" ? "pull_request" : parentKind;
+  const parentField =
+    parentKind === "pull_request"
+      ? "parent_pr"
+      : parentKind === "issue"
+        ? "parent_issue"
+        : "parent_discussion";
+
+  const [parentRows] = await db.query<[Array<{ id: unknown }>]>(
+    `SELECT id FROM ${parentTable} WHERE github_node_id = $node_id`,
+    { node_id: parentNodeId },
+  );
+  if (parentRows.length === 0) return { tombstoned: 0 };
+
+  const parentRef = new StringRecordId(String(parentRows[0].id));
+
+  const [localComments] = await db.query<[Array<{ id: unknown; github_node_id: string }>]>(
+    `SELECT id, github_node_id FROM comment WHERE ${parentField} = $parentRef AND deleted_at IS NONE`,
+    { parentRef },
+  );
+
+  const remoteSet = new Set(remoteCommentNodeIds);
+  const toTombstone = localComments.filter((c) => !remoteSet.has(c.github_node_id));
+
+  for (const comment of toTombstone) {
+    await db.query("UPDATE $id SET deleted_at = time::now()", {
+      id: new StringRecordId(String(comment.id)),
+    });
+  }
+
+  return { tombstoned: toTombstone.length };
+}


### PR DESCRIPTION
## Summary

Comment fetcher and persister, third milestone-1 ingest issue. Three per-parent async generators (`fetchCommentsForIssue` / `ForPullRequest` / `ForDiscussion`) plus a single DB-only `persistComment` and a `tombstoneMissingComments` helper for the orchestrator's reconciliation pass.

Mirrors the structure from #3 / #4 / #5: pure async generators, DB-only persister, zod-validated payloads, secondary pagination for discussion replies, NONE handling per CLAUDE.md.

## Schema delta

Added one nullable field to the `comment` table:

```surql
DEFINE FIELD IF NOT EXISTS parent_comment ON TABLE comment TYPE option<record<comment>>;
```

This honestly captures discussion reply threading (a top-level comment + its replies). Top-level comments and issue/PR comments leave it `NONE`. The migration is additive and idempotent (`IF NOT EXISTS`); no data migration needed.

## Design notes

- Matches the **current schema** (three nullable parent fields: `parent_issue`, `parent_pr`, `parent_discussion`), not the union refactor from #7's design spec. Refactor to union is deferred — `persistComment` already routes through a switch on `parent_kind` so the migration would be local.
- Persister **fails loudly** when the parent (or parent comment) is not found locally — by contract, the orchestrator must persist parents before their comments. The error message includes the GitHub node id of the missing parent.
- Discussion replies: secondary pagination uses the GraphQL global `node(id:)` query targeting `DiscussionComment.replies` for top-level comments with > 100 replies. Mirrors the per-PR commits secondary pagination from #4.
- `hashBody(body)` exported for #11; comments have no title.
- `tombstoneMissingComments` returns `{ tombstoned }` for the orchestrator's progress reporting. Edges (none yet — comment parentage is via record link, not edge) are unaffected per the structural-edge carve-out in `ARCHITECTURE.md`.

## Test plan

- [x] `bun run typecheck` — clean.
- [x] `bun test` — 70/70 pass across 12 files.
- [x] Persist tests for each parent kind: only the right `parent_*` field is set.
- [x] Discussion reply: top-level + reply both persisted; reply has `parent_comment` linking back to top-level.
- [x] Idempotency: re-persist same comment, no duplicate user, same row.
- [x] `tombstoneMissingComments` sets `deleted_at` only on locally-present-but-remotely-missing comments.
- [x] `parent not found` raises with the GitHub node id when persisting an orphan comment.
- [ ] `bun run smoke:*` (manual; unaffected).

## Out of scope

- PR review comments / review threads (only general PR comments, the conversation-tab connection).
- Reactions on comments.
- Cross-references in comment body (#8).
- Refactor of three `parent_*` fields into a union (separate concern).
- Embedding (#11).
- Discussion answer-link resolution (lives in `resolveDiscussionAnswerLinks` from #5; orchestrator wires it).

Closes #7


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add comment ingestion for issues, PRs, and discussions, including reply threading for discussions. Adds persistence and reconciliation to keep local comments in sync with GitHub. Closes #7.

- **New Features**
  - Async fetchers: `fetchCommentsForIssue`, `fetchCommentsForPullRequest`, `fetchCommentsForDiscussion` (with secondary pagination for discussion replies).
  - `persistComment` sets the correct `parent_*` and `parent_comment` links, upserts authors, and errors if the parent is missing.
  - `tombstoneMissingComments` marks locally-present-but-remotely-missing comments as deleted.
  - `hashBody` normalizes CRLF to LF and hashes the body.

- **Migration**
  - Added `parent_comment` (nullable) to the `comment` table. Additive and idempotent; no data migration needed.

<sup>Written for commit 57ef500aa1f9476cb1d97e741ad96599eef3daa0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

