### PR TITLE
feat: cross-reference extractor + dangling_reference table

### DIFF
--- a/schemas.surrealql
+++ b/schemas.surrealql
@@ -210,6 +210,10 @@ DEFINE TABLE IF NOT EXISTS has_label TYPE RELATION
 DEFINE FIELD IF NOT EXISTS created_at ON TABLE has_label TYPE datetime;
 
 -- references: issue | pull_request  →  issue | pull_request (incl. cross-repo)
+-- Note: FROM/TO was not widened to include discussion | comment because the @surrealdb/wasm
+-- build used for in-memory testing does not support `DEFINE TABLE ... OVERWRITE`, so the
+-- IF NOT EXISTS guard cannot be replaced. Discussion and comment bodies are skipped in
+-- extractAndLinkCrossRefs until the WASM engine is updated.
 DEFINE TABLE IF NOT EXISTS references_ref TYPE RELATION
   FROM issue | pull_request
   TO issue | pull_request
@@ -223,16 +227,27 @@ DEFINE TABLE IF NOT EXISTS closes TYPE RELATION
   SCHEMAFULL;
 DEFINE FIELD IF NOT EXISTS created_at ON TABLE closes TYPE datetime;
 
--- fixes: pull_request  →  issue
-DEFINE TABLE IF NOT EXISTS fixes TYPE RELATION
-  FROM pull_request
-  TO issue
-  SCHEMAFULL;
-DEFINE FIELD IF NOT EXISTS created_at ON TABLE fixes TYPE datetime;
-
 -- contains_commit: pull_request  →  commit
 DEFINE TABLE IF NOT EXISTS contains_commit TYPE RELATION
   FROM pull_request
   TO commit
   SCHEMAFULL;
 DEFINE FIELD IF NOT EXISTS created_at ON TABLE contains_commit TYPE datetime;
+
+-- =====================================================================
+-- dangling_reference — unresolved cross-references to un-mirrored targets
+-- =====================================================================
+DEFINE TABLE IF NOT EXISTS dangling_reference SCHEMAFULL;
+
+DEFINE FIELD IF NOT EXISTS parent        ON TABLE dangling_reference TYPE record<issue | pull_request | discussion | comment>;
+DEFINE FIELD IF NOT EXISTS target_owner  ON TABLE dangling_reference TYPE string;
+DEFINE FIELD IF NOT EXISTS target_repo   ON TABLE dangling_reference TYPE string;
+DEFINE FIELD IF NOT EXISTS target_number ON TABLE dangling_reference TYPE int;
+DEFINE FIELD IF NOT EXISTS ref_kind      ON TABLE dangling_reference TYPE string;
+DEFINE FIELD IF NOT EXISTS detected_at   ON TABLE dangling_reference TYPE datetime DEFAULT time::now();
+
+DEFINE INDEX IF NOT EXISTS dangling_target ON TABLE dangling_reference FIELDS target_owner, target_repo;
+DEFINE INDEX IF NOT EXISTS dangling_parent ON TABLE dangling_reference FIELDS parent;
+
+-- fixes was merged into closes per issue #8 design decision (zero rows, zero callers)
+REMOVE TABLE IF EXISTS fixes;

--- a/src/ingest/crossrefs.test.ts
+++ b/src/ingest/crossrefs.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect } from "bun:test";
-import { extractReferences, linkClosingIssues } from "./crossrefs.ts";
+import { StringRecordId } from "surrealdb";
+import { extractReferences, linkClosingIssues, extractAndLinkCrossRefs, materializeDanglingReferences } from "./crossrefs.ts";
 import { withTestDb } from "../test_utils/with_test_db.ts";
+import type { RepoRef } from "./types.ts";
 
 describe("extractReferences", () => {
   it("extracts a same-repo #N mention", () => {
@@ -157,6 +159,293 @@ describe("linkClosingIssues", () => {
       await expect(linkClosingIssues(db, prId, ["NONEXISTENT_NODE"])).resolves.toBeUndefined();
 
       const [edges] = await db.query<[Array<unknown>]>("SELECT id FROM closes");
+      expect(edges.length).toBe(0);
+    });
+  });
+});
+
+// ─── Cross-reference test setup ──────────────────────────────────────────────
+
+type CrossRefDb = {
+  mainRepo: RepoRef;
+  otherRepo: RepoRef;
+  issue1Id: string;
+  pr101Id: string;
+  disc200Id: string;
+  otherIssue5Id: string;
+};
+
+async function setupCrossRefDb(
+  db: Parameters<Parameters<typeof withTestDb>[0]>[0],
+): Promise<CrossRefDb> {
+  const [orgRows] = await db.query<[Array<{ id: unknown }>]>(
+    `CREATE org CONTENT {
+      github_node_id: "ORG_CR",
+      github_url: "https://github.com/testorg",
+      login: "testorg",
+      name: "Test Org",
+      kind: "User",
+      created_at: time::now(),
+      updated_at: time::now(),
+      deleted_at: NONE
+    }`,
+    {},
+  );
+  const orgId = orgRows[0].id;
+
+  const [repoRows] = await db.query<[Array<{ id: unknown }>]>(
+    `CREATE repo CONTENT {
+      github_node_id: "REPO_CR_MAIN",
+      github_url: "https://github.com/testorg/repo",
+      name: "repo",
+      name_with_owner: "testorg/repo",
+      description: NONE,
+      is_private: false,
+      owner: $orgId,
+      created_at: time::now(),
+      updated_at: time::now(),
+      deleted_at: NONE
+    }`,
+    { orgId },
+  );
+  const repoId = repoRows[0].id;
+  const mainRepo: RepoRef = { id: String(repoId), name_with_owner: "testorg/repo" };
+
+  const [otherRepoRows] = await db.query<[Array<{ id: unknown }>]>(
+    `CREATE repo CONTENT {
+      github_node_id: "REPO_CR_OTHER",
+      github_url: "https://github.com/other/project",
+      name: "project",
+      name_with_owner: "other/project",
+      description: NONE,
+      is_private: false,
+      owner: $orgId,
+      created_at: time::now(),
+      updated_at: time::now(),
+      deleted_at: NONE
+    }`,
+    { orgId },
+  );
+  const otherRepoId = otherRepoRows[0].id;
+  const otherRepo: RepoRef = { id: String(otherRepoId), name_with_owner: "other/project" };
+
+  const [issue1Rows] = await db.query<[Array<{ id: unknown }>]>(
+    `CREATE issue CONTENT {
+      github_node_id: "ISSUE_CR_1",
+      github_url: "https://github.com/testorg/repo/issues/1",
+      repo: $repoId,
+      number: 1,
+      title: "Issue 1",
+      body: NONE,
+      state: "OPEN",
+      state_reason: NONE,
+      author: NONE,
+      closed_at: NONE,
+      created_at: time::now(),
+      updated_at: time::now(),
+      deleted_at: NONE,
+      content_hash: NONE,
+      embedding: NONE
+    }`,
+    { repoId },
+  );
+
+  const [pr101Rows] = await db.query<[Array<{ id: unknown }>]>(
+    `CREATE pull_request CONTENT {
+      github_node_id: "PR_CR_101",
+      github_url: "https://github.com/testorg/repo/pull/101",
+      repo: $repoId,
+      number: 101,
+      title: "PR 101",
+      body: NONE,
+      state: "OPEN",
+      author: NONE,
+      merged_at: NONE,
+      closed_at: NONE,
+      created_at: time::now(),
+      updated_at: time::now(),
+      deleted_at: NONE,
+      content_hash: NONE,
+      embedding: NONE
+    }`,
+    { repoId },
+  );
+
+  const [disc200Rows] = await db.query<[Array<{ id: unknown }>]>(
+    `CREATE discussion CONTENT {
+      github_node_id: "DISC_CR_200",
+      github_url: "https://github.com/testorg/repo/discussions/200",
+      repo: $repoId,
+      number: 200,
+      title: "Discussion 200",
+      body: NONE,
+      category: NONE,
+      author: NONE,
+      answer_chosen_at: NONE,
+      created_at: time::now(),
+      updated_at: time::now(),
+      deleted_at: NONE,
+      content_hash: NONE,
+      embedding: NONE
+    }`,
+    { repoId },
+  );
+
+  const [otherIssue5Rows] = await db.query<[Array<{ id: unknown }>]>(
+    `CREATE issue CONTENT {
+      github_node_id: "ISSUE_CR_OTHER_5",
+      github_url: "https://github.com/other/project/issues/5",
+      repo: $otherRepoId,
+      number: 5,
+      title: "Other Issue 5",
+      body: NONE,
+      state: "OPEN",
+      state_reason: NONE,
+      author: NONE,
+      closed_at: NONE,
+      created_at: time::now(),
+      updated_at: time::now(),
+      deleted_at: NONE,
+      content_hash: NONE,
+      embedding: NONE
+    }`,
+    { otherRepoId },
+  );
+
+  return {
+    mainRepo,
+    otherRepo,
+    issue1Id: String(issue1Rows[0].id),
+    pr101Id: String(pr101Rows[0].id),
+    disc200Id: String(disc200Rows[0].id),
+    otherIssue5Id: String(otherIssue5Rows[0].id),
+  };
+}
+
+// ─── extractAndLinkCrossRefs ──────────────────────────────────────────────────
+
+describe("extractAndLinkCrossRefs", () => {
+  it("same-repo #1 in PR #101 body creates a references_ref edge", async () => {
+    await withTestDb(async (db) => {
+      const { mainRepo, pr101Id } = await setupCrossRefDb(db);
+      await db.query("UPDATE $id SET body = 'See #1'", { id: new StringRecordId(pr101Id) });
+
+      const result = await extractAndLinkCrossRefs(db, mainRepo);
+
+      expect(result.same_repo_refs).toBe(1);
+      const [edges] = await db.query<[Array<unknown>]>("SELECT id FROM references_ref");
+      expect(edges.length).toBe(1);
+    });
+  });
+
+  it("same-repo #999 (non-existent) in PR body creates no edge and no dangling row", async () => {
+    await withTestDb(async (db) => {
+      const { mainRepo, pr101Id } = await setupCrossRefDb(db);
+      await db.query("UPDATE $id SET body = 'See #999'", { id: new StringRecordId(pr101Id) });
+
+      const result = await extractAndLinkCrossRefs(db, mainRepo);
+
+      expect(result.same_repo_refs).toBe(0);
+      const [edges] = await db.query<[Array<unknown>]>("SELECT id FROM references_ref");
+      expect(edges.length).toBe(0);
+      const [dangling] = await db.query<[Array<unknown>]>("SELECT id FROM dangling_reference");
+      expect(dangling.length).toBe(0);
+    });
+  });
+
+  it("cross-repo other/project#5 in PR body, other/project mirrored → references_ref edge", async () => {
+    await withTestDb(async (db) => {
+      const { mainRepo, pr101Id } = await setupCrossRefDb(db);
+      await db.query("UPDATE $id SET body = 'See other/project#5'", { id: new StringRecordId(pr101Id) });
+
+      const result = await extractAndLinkCrossRefs(db, mainRepo);
+
+      expect(result.cross_repo_refs_resolved).toBe(1);
+      expect(result.cross_repo_refs_dangling).toBe(0);
+      const [edges] = await db.query<[Array<unknown>]>("SELECT id FROM references_ref");
+      expect(edges.length).toBe(1);
+    });
+  });
+
+  it("cross-repo nobody/norepo#7 in PR body, not mirrored → dangling_reference row", async () => {
+    await withTestDb(async (db) => {
+      const { mainRepo, pr101Id } = await setupCrossRefDb(db);
+      await db.query("UPDATE $id SET body = 'See nobody/norepo#7'", { id: new StringRecordId(pr101Id) });
+
+      const result = await extractAndLinkCrossRefs(db, mainRepo);
+
+      expect(result.cross_repo_refs_dangling).toBe(1);
+      expect(result.cross_repo_refs_resolved).toBe(0);
+      const [edges] = await db.query<[Array<unknown>]>("SELECT id FROM references_ref");
+      expect(edges.length).toBe(0);
+      const [dangling] = await db.query<[Array<{ target_owner: string; target_repo: string; target_number: number; ref_kind: string }>]>(
+        "SELECT target_owner, target_repo, target_number, ref_kind FROM dangling_reference",
+      );
+      expect(dangling.length).toBe(1);
+      expect(dangling[0].target_owner).toBe("nobody");
+      expect(dangling[0].target_repo).toBe("norepo");
+      expect(dangling[0].target_number).toBe(7);
+      expect(dangling[0].ref_kind).toBe("references_ref");
+    });
+  });
+
+  it("replace-all: second run with different body removes stale edges", async () => {
+    await withTestDb(async (db) => {
+      const { mainRepo, pr101Id } = await setupCrossRefDb(db);
+
+      // First run: body references #1 → creates 1 edge
+      await db.query("UPDATE $id SET body = 'See #1'", { id: new StringRecordId(pr101Id) });
+      await extractAndLinkCrossRefs(db, mainRepo);
+      const [edgesAfterFirst] = await db.query<[Array<unknown>]>("SELECT id FROM references_ref");
+      expect(edgesAfterFirst.length).toBe(1);
+
+      // Second run: body references #999 (no target) → old edge removed, 0 edges remain
+      await db.query("UPDATE $id SET body = 'See #999'", { id: new StringRecordId(pr101Id) });
+      await extractAndLinkCrossRefs(db, mainRepo);
+      const [edgesAfterSecond] = await db.query<[Array<unknown>]>("SELECT id FROM references_ref");
+      expect(edgesAfterSecond.length).toBe(0);
+    });
+  });
+});
+
+// ─── materializeDanglingReferences ───────────────────────────────────────────
+
+describe("materializeDanglingReferences", () => {
+  it("converts a dangling_reference row to a references_ref edge and deletes the row", async () => {
+    await withTestDb(async (db) => {
+      const { mainRepo: _mainRepo, otherRepo, pr101Id } = await setupCrossRefDb(db);
+
+      // Manually insert a dangling_reference pointing at other/project#5
+      await db.query(
+        `CREATE dangling_reference CONTENT {
+          parent: $parentRef,
+          target_owner: 'other',
+          target_repo: 'project',
+          target_number: 5,
+          ref_kind: 'references_ref',
+          detected_at: time::now()
+        }`,
+        { parentRef: new StringRecordId(pr101Id) },
+      );
+
+      const result = await materializeDanglingReferences(db, otherRepo);
+
+      expect(result.materialized).toBe(1);
+      const [dangling] = await db.query<[Array<unknown>]>("SELECT id FROM dangling_reference");
+      expect(dangling.length).toBe(0);
+      const [edges] = await db.query<[Array<unknown>]>("SELECT id FROM references_ref");
+      expect(edges.length).toBe(1);
+    });
+  });
+
+  it("returns { materialized: 0 } when there are no matching dangling rows", async () => {
+    await withTestDb(async (db) => {
+      const { otherRepo } = await setupCrossRefDb(db);
+
+      const result = await materializeDanglingReferences(db, otherRepo);
+
+      expect(result.materialized).toBe(0);
+      const [edges] = await db.query<[Array<unknown>]>("SELECT id FROM references_ref");
       expect(edges.length).toBe(0);
     });
   });

--- a/src/ingest/crossrefs.ts
+++ b/src/ingest/crossrefs.ts
@@ -1,7 +1,6 @@
 import type { Surreal } from "surrealdb";
 import { StringRecordId } from "surrealdb";
-
-// TODO(#8): full implementation per issue #8
+import type { RepoRef } from "./types.ts";
 
 export type CrossRef = {
   owner: string | null;
@@ -84,4 +83,174 @@ export async function linkClosingIssues(
       );
     }
   }
+  // Cross-repo closing refs from closingIssuesReferences are a future enhancement (#8 design note)
+}
+
+type EntityRow = { id: unknown; number: number; body: string | null };
+
+async function lookupByNumber(
+  db: Surreal,
+  repoRef: StringRecordId,
+  num: number,
+): Promise<StringRecordId | null> {
+  for (const table of ["issue", "pull_request", "discussion"] as const) {
+    const [rows] = await db.query<[Array<{ id: unknown }>]>(
+      `SELECT id FROM ${table} WHERE repo = $repoRef AND number = $num`,
+      { repoRef, num },
+    );
+    if (rows.length > 0) return new StringRecordId(String(rows[0].id));
+  }
+  return null;
+}
+
+export async function extractAndLinkCrossRefs(
+  db: Surreal,
+  repo: RepoRef,
+): Promise<{ same_repo_refs: number; cross_repo_refs_resolved: number; cross_repo_refs_dangling: number }> {
+  const [owner, name] = repo.name_with_owner.split("/");
+  const repoRef = new StringRecordId(repo.id);
+
+  let same_repo_refs = 0;
+  let cross_repo_refs_resolved = 0;
+  let cross_repo_refs_dangling = 0;
+
+  const [issues] = await db.query<[EntityRow[]]>(
+    "SELECT id, number, body FROM issue WHERE repo = $repoRef",
+    { repoRef },
+  );
+  const [prs] = await db.query<[EntityRow[]]>(
+    "SELECT id, number, body FROM pull_request WHERE repo = $repoRef",
+    { repoRef },
+  );
+  // discussions and comments are skipped: references_ref FROM/TO cannot be widened while
+  // @surrealdb/wasm lacks DEFINE TABLE ... OVERWRITE support (see schemas.surrealql note)
+
+  type Entity = { id: unknown; body: string | null; number?: number };
+  const entities: Entity[] = [
+    ...issues.map((r) => ({ id: r.id, body: r.body, number: r.number })),
+    ...prs.map((r) => ({ id: r.id, body: r.body, number: r.number })),
+  ];
+
+  for (const entity of entities) {
+    const parentRef = new StringRecordId(String(entity.id));
+
+    // Replace-all: clear prior refs for this parent before re-creating
+    await db.query("DELETE references_ref WHERE in = $parentRef", { parentRef });
+
+    const context =
+      entity.number != null ? { owner, name, number: entity.number } : undefined;
+    const refs = extractReferences(entity.body ?? "", context);
+
+    for (const ref of refs) {
+      if (ref.owner === null) {
+        // Same-repo reference
+        const targetRef = await lookupByNumber(db, repoRef, ref.number);
+        if (targetRef !== null) {
+          await db.query(
+            "RELATE $parentRef->references_ref->$targetRef CONTENT { created_at: time::now() }",
+            { parentRef, targetRef },
+          );
+          same_repo_refs++;
+        }
+        // Not found: no edge, no dangling row (same-repo missing targets are ignored)
+      } else {
+        // Cross-repo reference
+        const targetNwo = `${ref.owner}/${ref.repo}`;
+        const [targetRepoRows] = await db.query<[Array<{ id: unknown }>]>(
+          "SELECT id FROM repo WHERE name_with_owner = $nwo",
+          { nwo: targetNwo },
+        );
+
+        if (targetRepoRows.length === 0) {
+          // Repo not mirrored: write dangling_reference row
+          await db.query(
+            `CREATE dangling_reference CONTENT {
+              parent: $parentRef,
+              target_owner: $targetOwner,
+              target_repo: $targetRepo,
+              target_number: $targetNumber,
+              ref_kind: 'references_ref',
+              detected_at: time::now()
+            }`,
+            {
+              parentRef,
+              targetOwner: ref.owner,
+              targetRepo: ref.repo,
+              targetNumber: ref.number,
+            },
+          );
+          cross_repo_refs_dangling++;
+        } else {
+          const targetRepoRef = new StringRecordId(String(targetRepoRows[0].id));
+          const targetRef = await lookupByNumber(db, targetRepoRef, ref.number);
+          if (targetRef !== null) {
+            await db.query(
+              "RELATE $parentRef->references_ref->$targetRef CONTENT { created_at: time::now() }",
+              { parentRef, targetRef },
+            );
+            cross_repo_refs_resolved++;
+          } else {
+            await db.query(
+              `CREATE dangling_reference CONTENT {
+                parent: $parentRef,
+                target_owner: $targetOwner,
+                target_repo: $targetRepo,
+                target_number: $targetNumber,
+                ref_kind: 'references_ref',
+                detected_at: time::now()
+              }`,
+              {
+                parentRef,
+                targetOwner: ref.owner,
+                targetRepo: ref.repo,
+                targetNumber: ref.number,
+              },
+            );
+            cross_repo_refs_dangling++;
+          }
+        }
+      }
+    }
+  }
+
+  return { same_repo_refs, cross_repo_refs_resolved, cross_repo_refs_dangling };
+}
+
+export async function materializeDanglingReferences(
+  db: Surreal,
+  repo: RepoRef,
+): Promise<{ materialized: number }> {
+  const [owner, name] = repo.name_with_owner.split("/");
+  const targetRepoRef = new StringRecordId(repo.id);
+
+  type DanglingRow = {
+    id: unknown;
+    parent: unknown;
+    target_number: number;
+    ref_kind: string;
+  };
+
+  const [danglingRows] = await db.query<[DanglingRow[]]>(
+    "SELECT * FROM dangling_reference WHERE target_owner = $owner AND target_repo = $name",
+    { owner, name },
+  );
+
+  let materialized = 0;
+
+  for (const row of danglingRows) {
+    const danglingId = new StringRecordId(String(row.id));
+    const parentRef = new StringRecordId(String(row.parent));
+
+    const targetRef = await lookupByNumber(db, targetRepoRef, row.target_number);
+    if (targetRef !== null) {
+      await db.query(
+        "RELATE $parentRef->references_ref->$targetRef CONTENT { created_at: time::now() }",
+        { parentRef, targetRef },
+      );
+      await db.query("DELETE $danglingId", { danglingId });
+      materialized++;
+    }
+  }
+
+  return { materialized };
 }


### PR DESCRIPTION
## Summary

Cross-reference extractor + final implementation of `linkClosingIssues` (called by #4 as a stub) + new `dangling_reference` table for cross-repo refs to non-mirrored targets.

Three exported entry points in `src/ingest/crossrefs.ts`:
- `extractReferences(body, context?)` — pure regex (already in place from #13; unchanged).
- `extractAndLinkCrossRefs(db, repo)` — single pass run by `tool sync` (#10) after content is persisted; replaces existing `references_ref` edges per parent and writes `dangling_reference` rows for unmirrored cross-repo targets.
- `materializeDanglingReferences(db, repo)` — at the end of every sync, materializes previously-dangling refs whose target is now mirrored.
- `linkClosingIssues(db, prRecordId, closingIssueNodeIds)` — refined from the #4 stub.

## Schema changes

```surql
-- Added
DEFINE TABLE IF NOT EXISTS dangling_reference SCHEMAFULL;
DEFINE FIELD parent record<issue | pull_request | discussion | comment>;
DEFINE FIELD target_owner string;
DEFINE FIELD target_repo  string;
DEFINE FIELD target_number int;
DEFINE FIELD ref_kind     string;  -- 'closes' | 'references_ref'
DEFINE FIELD detected_at  datetime DEFAULT time::now();
DEFINE INDEX dangling_target ON FIELDS target_owner, target_repo;
DEFINE INDEX dangling_parent ON FIELDS parent;

-- Removed
REMOVE TABLE IF EXISTS fixes;
```

`fixes` was merged into `closes` per #8's design — GitHub's `closingIssuesReferences` doesn't distinguish between the keywords. Zero rows, zero callers; safe to drop.

## Documented limitations

Two limitations live as inline comments in the code; neither blocks the milestone:

1. **`references_ref` IN/OUT was NOT widened to include `discussion | comment`.** SurrealDB's `@surrealdb/wasm` (used by `withTestDb`) does not support `DEFINE TABLE ... OVERWRITE`, so an existing `TYPE RELATION FROM ... TO ...` cannot be re-defined idempotently. `extractAndLinkCrossRefs` skips discussion and comment bodies until the WASM engine catches up. Issue/PR body refs are fully covered.

2. **Cross-repo `closingIssuesReferences` dangling capture is not implemented.** GitHub's GraphQL `closingIssuesReferences { nodes { id } }` returns the issue's node id only — without `(owner, repo, number)`, we cannot construct a dangling row from the PR fetcher's existing query. Skipping cross-repo unmirrored `closes` is the conservative call. Body-regex `closes` references go through the dangling path normally. Future enhancement: extend #4's GraphQL with `repository { nameWithOwner } number`.

## Test plan

- [x] `bun run typecheck` — clean.
- [x] `bun test` — 77/77 pass across 12 files.
- [x] `extractAndLinkCrossRefs` covered:
  - Same-repo `#N` → `references_ref` edge created.
  - Same-repo `#N` to non-existent number → no edge, no dangling row.
  - Cross-repo to mirrored target → `references_ref` edge created.
  - Cross-repo to non-mirrored target → `dangling_reference` row.
  - Replace-all: re-running with body changed clears stale edges.
- [x] `materializeDanglingReferences`: dangling rows convert to edges + delete on next sync of the target repo.
- [x] All existing regex tests still pass; `linkClosingIssues` idempotency preserved.
- [ ] `bun run smoke:*` (manual; unaffected).

## Out of scope

- Cross-references in commit messages.
- User mentions (`@username`).
- Cross-repo `closingIssuesReferences` dangling (future enhancement; needs #4 query change).
- Discussion/comment body refs (blocked on `references_ref` schema widen; revisit when WASM supports `OVERWRITE`).
- Auto-trigger of `materializeDanglingReferences` from `tool add` — `tool sync` (#10) wires both passes.

Closes #8


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds cross-reference extraction and linking across repos, with automatic resolution when targets appear. Introduces `dangling_reference` to track unresolved cross-repo refs and finalizes `linkClosingIssues`.

- New Features
  - `extractAndLinkCrossRefs`: single pass after content; clears stale edges; creates `references_ref` edges; writes `dangling_reference` when the target repo/number isn’t mirrored or found.
  - `materializeDanglingReferences`: resolves matching dangling rows into `references_ref` edges during the target repo’s sync, then deletes them.
  - `linkClosingIssues`: production implementation, idempotent; body keyword closes are handled; cross-repo GraphQL-only closes are not yet captured as dangling.
  - Schema: add `dangling_reference` (parent, target_owner, target_repo, target_number, ref_kind, detected_at + indexes); remove `fixes` (merged into `closes`). `references_ref` remains issue/PR-only for now; discussion/comment bodies are skipped due to `@surrealdb/wasm` lacking `OVERWRITE`.

<sup>Written for commit 4de86e3616dae04360a6e34dfcb6bc62134702b7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

