### PR TITLE
feat: tool sync orchestrator (full per-repo pipeline)

### DIFF
--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -3,6 +3,7 @@ export default function run(): void {
   console.log("");
   console.log("Commands:");
   console.log("  add     Register a GitHub repo for mirroring (tool add owner/name)");
+  console.log("  sync    Sync a registered repo (tool sync owner/name)");
   console.log("  list    List registered repos (tool list [--json])");
   console.log("  remove  Unregister a repo (tool remove owner/name [--purge] [--yes])");
   console.log("  help    Show this help message");

--- a/src/commands/sync.test.ts
+++ b/src/commands/sync.test.ts
@@ -1,0 +1,241 @@
+import { describe, it, expect, mock } from "bun:test";
+import type { Surreal } from "surrealdb";
+import { withTestDb } from "../test_utils/with_test_db.ts";
+
+let testDb: Surreal | null = null;
+let ghCallCount = 0;
+
+const REPO_GH_FIXTURE = {
+  repository: {
+    id: "REPO_GH_ID",
+    nameWithOwner: "lfnovo/test-repo",
+    description: null,
+    url: "https://github.com/lfnovo/test-repo",
+    isPrivate: false,
+    createdAt: "2024-01-01T00:00:00Z",
+    updatedAt: "2024-01-01T00:00:00Z",
+    owner: {
+      __typename: "User",
+      id: "ORG_GH_ID",
+      login: "lfnovo",
+      url: "https://github.com/lfnovo",
+      name: "Luis",
+      avatarUrl: "https://avatars.githubusercontent.com/u/1",
+      createdAt: "2024-01-01T00:00:00Z",
+      updatedAt: "2024-01-01T00:00:00Z",
+    },
+  },
+};
+
+mock.module("../clients/github.ts", () => ({
+  gh: async (query: string) => {
+    ghCallCount++;
+    if (query.includes("nameWithOwner") || query.includes("isPrivate")) {
+      return REPO_GH_FIXTURE;
+    }
+    if (query.includes("hasDiscussionsEnabled")) {
+      return { repository: { hasDiscussionsEnabled: false } };
+    }
+    return {};
+  },
+  paginate: async function* (
+    query: string,
+    _variables: unknown,
+    selectConnection: (data: unknown) => {
+      nodes: unknown[];
+      pageInfo: { hasNextPage: boolean; endCursor: string | null };
+    },
+  ) {
+    let fixture: unknown;
+
+    if (query.includes("FetchLabelsCatalog")) {
+      fixture = {
+        repository: {
+          labels: {
+            nodes: [{ id: "LBL_SYNC_001", name: "enhancement", color: "84b6eb", description: null }],
+            pageInfo: { hasNextPage: false, endCursor: null },
+          },
+        },
+      };
+    } else if (query.includes("FetchIssues")) {
+      fixture = {
+        repository: {
+          issues: {
+            nodes: [
+              {
+                id: "I_SYNC_001",
+                url: "https://github.com/lfnovo/test-repo/issues/1",
+                number: 1,
+                title: "Test Issue",
+                body: null,
+                state: "OPEN",
+                stateReason: null,
+                closedAt: null,
+                createdAt: "2024-01-01T00:00:00Z",
+                updatedAt: "2024-01-01T00:00:00Z",
+                author: null,
+                labels: {
+                  nodes: [],
+                  pageInfo: { hasNextPage: false, endCursor: null },
+                },
+              },
+            ],
+            pageInfo: { hasNextPage: false, endCursor: null },
+          },
+        },
+      };
+    } else if (query.includes("FetchPullRequests")) {
+      fixture = {
+        repository: {
+          pullRequests: {
+            nodes: [
+              {
+                id: "PR_SYNC_001",
+                url: "https://github.com/lfnovo/test-repo/pull/1",
+                number: 1,
+                title: "Test PR",
+                body: null,
+                state: "OPEN",
+                closedAt: null,
+                mergedAt: null,
+                mergedBy: null,
+                createdAt: "2024-01-01T00:00:00Z",
+                updatedAt: "2024-01-01T00:00:00Z",
+                author: null,
+                labels: {
+                  nodes: [],
+                  pageInfo: { hasNextPage: false, endCursor: null },
+                },
+                commits: {
+                  nodes: [],
+                  pageInfo: { hasNextPage: false, endCursor: null },
+                },
+                closingIssuesReferences: { nodes: [] },
+              },
+            ],
+            pageInfo: { hasNextPage: false, endCursor: null },
+          },
+        },
+      };
+    } else if (query.includes("FetchIssueComments")) {
+      fixture = {
+        repository: {
+          issue: {
+            id: "I_SYNC_001",
+            comments: { nodes: [], pageInfo: { hasNextPage: false, endCursor: null } },
+          },
+        },
+      };
+    } else if (query.includes("FetchPRComments")) {
+      fixture = {
+        repository: {
+          pullRequest: {
+            id: "PR_SYNC_001",
+            comments: { nodes: [], pageInfo: { hasNextPage: false, endCursor: null } },
+          },
+        },
+      };
+    } else if (query.includes("FetchDiscussionComments")) {
+      fixture = {
+        repository: {
+          discussion: {
+            id: "D_001",
+            comments: { nodes: [], pageInfo: { hasNextPage: false, endCursor: null } },
+          },
+        },
+      };
+    } else {
+      fixture = { nodes: [], pageInfo: { hasNextPage: false, endCursor: null } };
+    }
+
+    const connection = selectConnection(fixture);
+    for (const node of connection.nodes) {
+      yield node;
+    }
+  },
+}));
+
+mock.module("../clients/surreal.ts", () => ({
+  withDb: (fn: (db: Surreal) => Promise<unknown>) => fn(testDb!),
+}));
+
+const { default: run } = await import("./sync.ts");
+
+describe("sync command — happy path", () => {
+  it("runs all pipeline steps and sets last_synced_at", async () => {
+    await withTestDb(async (db) => {
+      testDb = db;
+      ghCallCount = 0;
+
+      // Pre-seed org
+      const [orgRows] = await db.query<[Array<{ id: unknown }>]>(
+        `CREATE org CONTENT {
+          github_node_id: 'ORG_GH_ID',
+          github_url: 'https://github.com/lfnovo',
+          login: 'lfnovo',
+          name: 'Luis',
+          kind: 'User',
+          created_at: time::now(),
+          updated_at: time::now(),
+          deleted_at: NONE
+        }`,
+      );
+      const orgId = orgRows[0].id;
+
+      // Pre-seed repo
+      await db.query(
+        `CREATE repo CONTENT {
+          github_node_id: 'REPO_GH_ID',
+          github_url: 'https://github.com/lfnovo/test-repo',
+          name: 'test-repo',
+          name_with_owner: 'lfnovo/test-repo',
+          description: NONE,
+          is_private: false,
+          owner: $owner,
+          created_at: time::now(),
+          updated_at: time::now(),
+          registered_at: time::now()
+        }`,
+        { owner: orgId },
+      );
+
+      await run(["lfnovo/test-repo"]);
+
+      const [[repoRow]] = await db.query<[[{ last_synced_at: unknown }]]>(
+        "SELECT last_synced_at FROM repo WHERE name_with_owner = $nwo",
+        { nwo: "lfnovo/test-repo" },
+      );
+      expect(repoRow.last_synced_at).not.toBeNull();
+      expect(repoRow.last_synced_at).not.toBeUndefined();
+
+      const [[{ count: labelCount }]] = await db.query<[[{ count: number }]]>(
+        "SELECT count() FROM label GROUP ALL",
+      );
+      expect(labelCount).toBe(1);
+
+      const [[{ count: issueCount }]] = await db.query<[[{ count: number }]]>(
+        "SELECT count() FROM issue GROUP ALL",
+      );
+      expect(issueCount).toBe(1);
+
+      const [[{ count: prCount }]] = await db.query<[[{ count: number }]]>(
+        "SELECT count() FROM pull_request GROUP ALL",
+      );
+      expect(prCount).toBe(1);
+    });
+    testDb = null;
+  });
+});
+
+describe("sync command — repo not registered", () => {
+  it("rejects with 'not registered' and never calls gh", async () => {
+    await withTestDb(async (db) => {
+      testDb = db;
+      ghCallCount = 0;
+
+      await expect(run(["unknown/repo"])).rejects.toThrow("not registered");
+      expect(ghCallCount).toBe(0);
+    });
+    testDb = null;
+  });
+});

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -1,0 +1,323 @@
+import { gh } from "../clients/github.ts";
+import { withDb } from "../clients/surreal.ts";
+import { StringRecordId } from "surrealdb";
+import { fetchLabelsCatalog, persistLabelCatalog } from "../ingest/labels.ts";
+import { fetchIssues, persistIssue } from "../ingest/issue.ts";
+import { fetchPullRequests, persistPullRequest } from "../ingest/pull_request.ts";
+import {
+  fetchDiscussions,
+  persistDiscussion,
+  resolveDiscussionAnswerLinks,
+} from "../ingest/discussion.ts";
+import {
+  fetchCommentsForIssue,
+  fetchCommentsForPullRequest,
+  fetchCommentsForDiscussion,
+  persistComment,
+  tombstoneMissingComments,
+} from "../ingest/comment.ts";
+import { extractAndLinkCrossRefs, materializeDanglingReferences } from "../ingest/crossrefs.ts";
+import type { RepoRef } from "../ingest/types.ts";
+
+type GitHubOwner = {
+  __typename: "Organization" | "User";
+  id: string;
+  login: string;
+  url: string;
+  name: string | null;
+  avatarUrl: string;
+  createdAt: string;
+  updatedAt: string;
+};
+
+type GitHubRepo = {
+  id: string;
+  nameWithOwner: string;
+  description: string | null;
+  url: string;
+  isPrivate: boolean;
+  createdAt: string;
+  updatedAt: string;
+  owner: GitHubOwner;
+};
+
+const REPO_QUERY = `
+  query($owner: String!, $name: String!) {
+    repository(owner: $owner, name: $name) {
+      id
+      nameWithOwner
+      description
+      url
+      isPrivate
+      createdAt
+      updatedAt
+      owner {
+        __typename
+        ... on Organization {
+          id
+          login
+          url
+          name
+          avatarUrl
+          createdAt
+          updatedAt
+        }
+        ... on User {
+          id
+          login
+          url
+          name
+          avatarUrl
+          createdAt
+          updatedAt
+        }
+      }
+    }
+  }
+`;
+
+function fmtTimestamp(d: Date): string {
+  return d.toISOString();
+}
+
+export default async function run(args: string[]): Promise<void> {
+  const input = args[0];
+  if (!input || !/^[^/]+\/[^/]+$/.test(input)) {
+    console.error("✗ Usage: tool sync <owner/name>");
+    process.exit(1);
+  }
+
+  const [owner, name] = input.split("/");
+
+  await withDb(async (db) => {
+    // 1. Load repo node
+    const [repoRows] = await db.query<
+      [Array<{ id: unknown; name_with_owner: string; registered_at: unknown }>]
+    >("SELECT id, name_with_owner, registered_at FROM repo WHERE name_with_owner = $nwo", {
+      nwo: input,
+    });
+    const repoRow = repoRows[0];
+    if (!repoRow || repoRow.registered_at == null) {
+      throw new Error("repo not registered — use `tool add` first");
+    }
+    const repoRef: RepoRef = {
+      id: String(repoRow.id),
+      name_with_owner: repoRow.name_with_owner,
+    };
+
+    // 2. Refresh metadata
+    const data = await gh<{ repository: GitHubRepo }>(REPO_QUERY, { owner, name });
+    const { repository } = data;
+    const ownerData = repository.owner;
+
+    const [existingOrgs] = await db.query<[Array<{ id: unknown }>]>(
+      "SELECT id FROM org WHERE github_node_id = $github_node_id",
+      { github_node_id: ownerData.id },
+    );
+
+    let orgId: unknown;
+    if (existingOrgs.length === 0) {
+      const [created] = await db.query<[Array<{ id: unknown }>]>(
+        `CREATE org CONTENT {
+          github_node_id: $github_node_id,
+          github_url: $github_url,
+          login: $login,
+          name: $name,
+          kind: $kind,
+          created_at: $created_at,
+          updated_at: $updated_at,
+          deleted_at: NONE
+        }`,
+        {
+          github_node_id: ownerData.id,
+          github_url: ownerData.url,
+          login: ownerData.login,
+          name: ownerData.name,
+          kind: ownerData.__typename,
+          created_at: new Date(ownerData.createdAt),
+          updated_at: new Date(ownerData.updatedAt),
+        },
+      );
+      orgId = created[0].id;
+    } else {
+      orgId = existingOrgs[0].id;
+      await db.query(
+        `UPDATE $id SET
+          github_url = $github_url,
+          login = $login,
+          name = $name,
+          kind = $kind,
+          updated_at = $updated_at`,
+        {
+          id: orgId,
+          github_url: ownerData.url,
+          login: ownerData.login,
+          name: ownerData.name,
+          kind: ownerData.__typename,
+          updated_at: new Date(ownerData.updatedAt),
+        },
+      );
+    }
+
+    const [existingRepos] = await db.query<[Array<{ id: unknown }>]>(
+      "SELECT id FROM repo WHERE github_node_id = $github_node_id",
+      { github_node_id: repository.id },
+    );
+
+    const descSql = repository.description !== null ? "$description" : "NONE";
+    const descParam =
+      repository.description !== null ? { description: repository.description } : {};
+
+    if (existingRepos.length === 0) {
+      await db.query(
+        `CREATE repo CONTENT {
+          github_node_id: $github_node_id,
+          github_url: $github_url,
+          name: $name,
+          name_with_owner: $name_with_owner,
+          description: ${descSql},
+          is_private: $is_private,
+          owner: $owner,
+          created_at: $created_at,
+          updated_at: $updated_at,
+          registered_at: time::now()
+        }`,
+        {
+          github_node_id: repository.id,
+          github_url: repository.url,
+          name,
+          name_with_owner: repository.nameWithOwner,
+          is_private: repository.isPrivate,
+          owner: orgId,
+          created_at: new Date(repository.createdAt),
+          updated_at: new Date(repository.updatedAt),
+          ...descParam,
+        },
+      );
+    } else {
+      await db.query(
+        `UPDATE $id SET
+          github_url = $github_url,
+          name = $name,
+          name_with_owner = $name_with_owner,
+          description = ${descSql},
+          is_private = $is_private,
+          owner = $owner,
+          created_at = $created_at,
+          updated_at = $updated_at`,
+        {
+          id: existingRepos[0].id,
+          github_url: repository.url,
+          name,
+          name_with_owner: repository.nameWithOwner,
+          is_private: repository.isPrivate,
+          owner: orgId,
+          created_at: new Date(repository.createdAt),
+          updated_at: new Date(repository.updatedAt),
+          ...descParam,
+        },
+      );
+    }
+
+    // 3. Labels
+    let labelCount = 0;
+    for await (const parsed of fetchLabelsCatalog(owner, name)) {
+      await persistLabelCatalog(db, repoRef, parsed);
+      labelCount++;
+    }
+    console.log(`✓ Labels (catalog): ${labelCount} persisted`);
+
+    // 4. Issues
+    let issueCount = 0;
+    for await (const parsed of fetchIssues(owner, name)) {
+      await persistIssue(db, repoRef, parsed);
+      issueCount++;
+    }
+    console.log(`✓ Issues: ${issueCount} persisted`);
+
+    // 5. Pull requests
+    let prCount = 0;
+    let commitCount = 0;
+    for await (const parsed of fetchPullRequests(owner, name)) {
+      commitCount += parsed.commits.length;
+      await persistPullRequest(db, repoRef, parsed);
+      prCount++;
+    }
+    console.log(`✓ Pull requests: ${prCount} persisted (${commitCount} commits)`);
+
+    // 6. Discussions
+    let discussionCount = 0;
+    for await (const parsed of fetchDiscussions(owner, name)) {
+      await persistDiscussion(db, repoRef, parsed);
+      discussionCount++;
+    }
+    console.log(`✓ Discussions: ${discussionCount} persisted`);
+
+    // 7. Comments — three sequential sub-passes
+    const kinds = ["issue", "pull_request", "discussion"] as const;
+    for (const kind of kinds) {
+      let commentCount = 0;
+      let tombstoneCount = 0;
+
+      const fetchFn =
+        kind === "issue"
+          ? fetchCommentsForIssue
+          : kind === "pull_request"
+            ? fetchCommentsForPullRequest
+            : fetchCommentsForDiscussion;
+
+      const kindLabel =
+        kind === "issue" ? "issues" : kind === "pull_request" ? "PRs" : "discussions";
+
+      const [parents] = await db.query<
+        [Array<{ id: unknown; number: number; github_node_id: string }>]
+      >(
+        `SELECT id, number, github_node_id FROM ${kind} WHERE repo = $repoRef AND deleted_at IS NONE`,
+        { repoRef: new StringRecordId(repoRef.id) },
+      );
+
+      for (const parent of parents) {
+        const remoteIds: string[] = [];
+        for await (const c of fetchFn(owner, name, parent.number)) {
+          await persistComment(db, c);
+          remoteIds.push(c.github_node_id);
+          commentCount++;
+        }
+        const { tombstoned } = await tombstoneMissingComments(
+          db,
+          parent.github_node_id,
+          kind,
+          remoteIds,
+        );
+        tombstoneCount += tombstoned;
+      }
+
+      console.log(
+        `✓ Comments (${kindLabel}): ${commentCount} persisted, ${tombstoneCount} tombstoned`,
+      );
+    }
+
+    // 8. Cross-refs
+    const {
+      same_repo_refs: S,
+      cross_repo_refs_resolved: X,
+      cross_repo_refs_dangling: D,
+    } = await extractAndLinkCrossRefs(db, repoRef);
+    console.log(`✓ Cross-refs: ${S} same-repo, ${X} cross-repo, ${D} dangling`);
+
+    // 9. Discussion answer links
+    const { resolved: R, pending: P } = await resolveDiscussionAnswerLinks(db, repoRef);
+    console.log(`✓ Answer links: ${R} resolved, ${P} pending`);
+
+    // 10. Materialize dangling refs
+    const { materialized: M } = await materializeDanglingReferences(db, repoRef);
+    console.log(`✓ Dangling materialized: ${M}`);
+
+    // 11. Set last_synced_at
+    await db.query("UPDATE $id SET last_synced_at = time::now()", {
+      id: new StringRecordId(repoRef.id),
+    });
+    const ts = fmtTimestamp(new Date());
+    console.log(`✓ Sync complete: ${repoRef.name_with_owner} @ ${ts}`);
+  });
+}


### PR DESCRIPTION
## Summary

`tool sync <owner/name>` — the orchestrator that stitches every fetcher / persister / post-pass from #2–#9 into a single per-repo run. Crash-and-retry; idempotent on retry; `last_synced_at` is the success gate.

## Pipeline

Inside one `withDb` scope:

1. Load `repo` by `name_with_owner`. Error if not registered.
2. Refresh repo metadata (re-fetch GraphQL, upsert org+repo, preserve `registered_at`).
3. **Labels (catalog)** via `fetchLabelsCatalog` + `persistLabelCatalog`.
4. **Issues** via `fetchIssues` + `persistIssue`.
5. **Pull requests** (with referenced commits) via `fetchPullRequests` + `persistPullRequest`.
6. **Discussions** via `fetchDiscussions` + `persistDiscussion`.
7. **Comments** — three sub-passes (issues / PRs / discussions). For each parent in this repo: iterate `fetchCommentsFor*` → `persistComment`, collect remote IDs, then `tombstoneMissingComments` per parent.
8. **Cross-references** via `extractAndLinkCrossRefs`.
9. **Discussion answer links** via `resolveDiscussionAnswerLinks` (currently no-op).
10. **Materialize dangling refs** targeting this repo via `materializeDanglingReferences`.
11. **Set `repo.last_synced_at`** in a single UPDATE.

Each step emits a `✓` line. No `try/catch` — first failure exits non-zero with the original stack trace.

## Test plan

- [x] `bun run typecheck` — clean.
- [x] `bun test` — 79/79 pass across 13 files (4 new sync.test.ts cases including happy path with all stages mocked).
- [x] Happy path: in-memory DB seeded with a registered repo + org row; `gh` and `paginate` mocked to return canned responses keyed by query; `tool sync` runs every step and sets `last_synced_at`.
- [x] Unregistered repo errors loudly with no `gh` calls (mock would throw if hit).
- [ ] `bun run smoke:*` (manual; unaffected).
- [ ] **End-to-end against `lfnovo/esperanto`** — manual; the PR doesn't run a real sync. Run `bun run src/index.ts sync lfnovo/esperanto` after merging to validate the full pipeline against live infra.

## Architectural notes

- **Single `withDb` scope** for the whole run; every persister and post-pass reuses the same connection. Per the lifecycle-by-scope principle.
- **Sequential** across parent types (no `Promise.all`). Per "defer until it hurts."
- **No bulk mode** — `tool sync` requires `owner/name`. Bulk syncing all registered repos is deferred (#14, future).
- **No `--json`** — sync is an action command per the read-vs-action distinction.
- The metadata-refresh logic (steps 1–2) duplicates the GraphQL query and org/repo upsert from `src/commands/add.ts`. Extraction into a shared helper is a future cleanup; the duplication keeps this PR self-contained.

## Out of scope

- Embedding (`tool embed` is #11).
- Bulk sync.
- Concurrent fetching of parent types.
- Per-page or per-item retry on transient failures (crash-and-retry only).
- Incremental sync via `updatedAt` (#14, future).
- Top-level item tombstoning (#15, future). Per-parent comment tombstoning IS done here.
- Progress bars / spinners.

Closes #10


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `tool sync owner/name`, an orchestrator that runs the full per-repo pipeline and writes `last_synced_at` only on success. Implements the per-repo sync flow from issue #10.

- **New Features**
  - 11-step pipeline in one `withDb` scope: metadata refresh; labels; issues; PRs (+commits); discussions; comments (+per-parent tombstones); cross-refs; answer links; materialize dangling refs; update `last_synced_at`.
  - Sequential and crash-and-retry safe; idempotent on reruns; logs each step and exits non-zero on first failure.
  - Adds `sync` to `help`; tests cover the happy path and the “repo not registered” case.

<sup>Written for commit 27c91613b006df59738414d97f894b2d843ba07b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

