### PR TITLE
feat: tool inspect + QUERIES.md (milestone verification surface)

### DIFF
--- a/QUERIES.md
+++ b/QUERIES.md
@@ -1,0 +1,339 @@
+# QUERIES.md
+
+Documented SurrealQL examples for `github-embedder-surrealdb`.
+
+> **Note:** Examples are tested against the schema only (no live data at PR time). Run `surreal sql --conn http://localhost:8018 --user root --pass root --ns githubembed --db main` to execute interactively.
+
+---
+
+## 1. Counts and Coverage
+
+### Total non-tombstoned items per type for a repo
+
+Fetch the repo record first, then count per table. Replace `'lfnovo/esperanto'` with any `name_with_owner` value.
+
+```surql
+LET $repo = (SELECT id FROM repo WHERE name_with_owner = 'lfnovo/esperanto' AND registered_at != NONE)[0];
+
+SELECT count() AS total FROM issue          WHERE repo = $repo.id AND deleted_at IS NONE GROUP ALL;
+SELECT count() AS total FROM pull_request   WHERE repo = $repo.id AND deleted_at IS NONE GROUP ALL;
+SELECT count() AS total FROM discussion     WHERE repo = $repo.id AND deleted_at IS NONE GROUP ALL;
+SELECT count() AS total FROM comment
+  WHERE (parent_issue.repo = $repo.id OR parent_pr.repo = $repo.id OR parent_discussion.repo = $repo.id)
+    AND deleted_at IS NONE
+  GROUP ALL;
+```
+
+> ```json
+> [{ "total": 42 }]
+> [{ "total": 17 }]
+> [{ "total": 3 }]
+> [{ "total": 128 }]
+> ```
+
+### Embedding coverage per type
+
+Shows how many items are embeddable (non-bot, non-tombstoned) and how many have been embedded. Bot-authored content is excluded per the bot policy (bots are ingested but not embedded).
+
+```surql
+LET $repo = (SELECT id FROM repo WHERE name_with_owner = 'lfnovo/esperanto' AND registered_at != NONE)[0];
+
+SELECT
+  count()                                            AS total,
+  count(WHERE author.is_bot != true)                 AS embeddable,
+  count(WHERE embedding != NONE AND author.is_bot != true) AS embedded
+FROM issue
+WHERE repo = $repo.id AND deleted_at IS NONE
+GROUP ALL;
+```
+
+> ```json
+> [{ "total": 42, "embeddable": 39, "embedded": 35 }]
+> ```
+
+Repeat replacing `issue` with `pull_request`, `discussion`, or `comment` as needed.
+
+---
+
+## 2. Joins via Record Link
+
+SurrealDB resolves record links in `SELECT` automatically — no explicit `JOIN` syntax required.
+
+### All comments on issue #N
+
+`comment.parent_issue` is a direct record link to `issue`; the dot notation traverses it in place.
+
+```surql
+SELECT *
+FROM comment
+WHERE parent_issue.number = 5
+  AND parent_issue.repo.name_with_owner = 'lfnovo/esperanto'
+  AND deleted_at IS NONE;
+```
+
+> ```json
+> [
+>   {
+>     "id": "comment:abc123",
+>     "body": "Looks good to me.",
+>     "author": "user:jsmith",
+>     "created_at": "2026-01-15T10:00:00Z"
+>   }
+> ]
+> ```
+
+### Organization of an issue
+
+`repo.owner` is a record link to `org`; dot-chaining resolves both links in one query.
+
+```surql
+SELECT title, repo.owner.login AS org
+FROM issue
+WHERE number = 5
+  AND repo.name_with_owner = 'lfnovo/esperanto';
+```
+
+> ```json
+> [{ "title": "Fix null pointer in config loader", "org": "lfnovo" }]
+> ```
+
+### All labels for an issue
+
+`has_label` is an edge table (`issue → label`). The `->edge->target` graph traversal syntax walks it.
+
+```surql
+SELECT title, ->has_label->label.name AS labels
+FROM issue
+WHERE number = 5
+  AND repo.name_with_owner = 'lfnovo/esperanto';
+```
+
+> ```json
+> [{ "title": "Fix null pointer in config loader", "labels": ["bug", "good first issue"] }]
+> ```
+
+_Relies on the `has_label` relation: `issue | pull_request | discussion → label`._
+
+---
+
+## 3. Vector Similarity (Semantic Search)
+
+The HNSW indexes are defined as:
+```
+DEFINE INDEX issue_embedding_hnsw ON TABLE issue FIELDS embedding HNSW DIMENSION 768 DIST COSINE TYPE F32;
+```
+(and equivalently for `pull_request`, `discussion`, `comment`.)
+
+### Find issues most similar to a query embedding
+
+`$query_vec` is a 768-dimension float array produced by Ollama `nomic-embed-text`. Two equivalent forms are shown.
+
+**Function form** — explicit scoring, useful when you need the score column:
+
+```surql
+SELECT id, number, title,
+       vector::similarity::cosine(embedding, $query_vec) AS score
+FROM issue
+WHERE embedding != NONE
+  AND deleted_at IS NONE
+ORDER BY score DESC
+LIMIT 10;
+-- $query_vec: 768-dim float array from Ollama nomic-embed-text
+```
+
+> ```json
+> [
+>   { "id": "issue:1", "number": 23, "title": "Add retry logic to sync", "score": 0.94 },
+>   { "id": "issue:2", "number": 7,  "title": "Sync stalls on large repos", "score": 0.91 }
+> ]
+> ```
+
+**ANN shorthand** — `<|K,COSINE|>` operator uses the HNSW index directly for approximate nearest-neighbour search:
+
+```surql
+SELECT id, number, title
+FROM issue
+WHERE embedding <|10,COSINE|> $query_vec
+  AND deleted_at IS NONE;
+-- $query_vec: 768-dim float array from Ollama nomic-embed-text
+```
+
+> ```json
+> [
+>   { "id": "issue:1", "number": 23, "title": "Add retry logic to sync" },
+>   { "id": "issue:2", "number": 7,  "title": "Sync stalls on large repos" }
+> ]
+> ```
+
+_The `<|K,COSINE|>` operator triggers the `issue_embedding_hnsw` index and returns up to K approximate nearest neighbours._
+
+### Find PRs similar to a given issue
+
+Reuse the issue's stored embedding — no re-query to Ollama needed.
+
+```surql
+LET $emb = (
+  SELECT embedding
+  FROM issue
+  WHERE number = 5
+    AND repo.name_with_owner = 'lfnovo/esperanto'
+)[0].embedding;
+
+SELECT id, number, title,
+       vector::similarity::cosine(embedding, $emb) AS score
+FROM pull_request
+WHERE embedding != NONE
+  AND deleted_at IS NONE
+ORDER BY score DESC
+LIMIT 5;
+```
+
+> ```json
+> [
+>   { "id": "pull_request:8", "number": 12, "title": "Implement retry in fetcher", "score": 0.89 },
+>   { "id": "pull_request:3", "number": 4,  "title": "Add pagination guard",       "score": 0.82 }
+> ]
+> ```
+
+_Uses the `pr_embedding_hnsw` index. Both issue and pull_request share the same 768-dim space, so cross-table comparison is meaningful._
+
+---
+
+## 4. Cross-References
+
+### All PRs that close issue #N
+
+The `closes` edge goes `pull_request → issue`. The inner subquery resolves the issue id; the outer query walks the edge in reverse.
+
+```surql
+SELECT id, number, title
+FROM pull_request
+WHERE id IN (
+  SELECT in FROM closes
+  WHERE out = (
+    SELECT id FROM issue
+    WHERE number = 5
+      AND repo.name_with_owner = 'lfnovo/esperanto'
+  )[0].id
+);
+```
+
+> ```json
+> [{ "id": "pull_request:7", "number": 11, "title": "Fix #5: null pointer in config" }]
+> ```
+
+_Relies on the `closes` relation: `pull_request → issue`. The `in` field on an edge record is the source (PR), `out` is the target (issue)._
+
+### All dangling references targeting a repo
+
+Dangling references are cross-references to issues or PRs in repos that have not been mirrored yet.
+
+```surql
+SELECT *
+FROM dangling_reference
+WHERE target_owner = 'lfnovo'
+  AND target_repo = 'esperanto';
+```
+
+> ```json
+> [
+>   {
+>     "id": "dangling_reference:xyz",
+>     "parent": "issue:42",
+>     "target_owner": "lfnovo",
+>     "target_repo": "esperanto",
+>     "target_number": 99,
+>     "ref_kind": "closes",
+>     "detected_at": "2026-05-01T09:00:00Z"
+>   }
+> ]
+> ```
+
+_Uses the `dangling_target` index on `(target_owner, target_repo)`. Run `tool mirror add lfnovo/esperanto` then re-sync to resolve these._
+
+---
+
+## 5. Recent Activity
+
+### Top-10 most recently updated issues across all repos
+
+```surql
+SELECT number, title, updated_at, repo.name_with_owner AS repo
+FROM issue
+WHERE deleted_at IS NONE
+ORDER BY updated_at DESC
+LIMIT 10;
+```
+
+> ```json
+> [
+>   { "number": 55, "title": "Stale embedding after body edit", "updated_at": "2026-05-02T18:30:00Z", "repo": "lfnovo/esperanto" },
+>   { "number": 23, "title": "Add retry logic to sync",         "updated_at": "2026-05-01T14:00:00Z", "repo": "lfnovo/other-repo" }
+> ]
+> ```
+
+_`repo.name_with_owner` is resolved in a single pass via the record link — no join syntax needed._
+
+---
+
+## 6. Bot Policy
+
+These queries confirm that no bot-authored content has been embedded. The expected count is 0 for all tables — embedding is skipped for bot authors at the embed stage.
+
+### Issues
+
+```surql
+SELECT count() AS bot_with_embeddings
+FROM issue
+WHERE embedding != NONE AND author.is_bot = true
+GROUP ALL;
+-- Expected: [{ "bot_with_embeddings": 0 }]
+```
+
+> ```json
+> [{ "bot_with_embeddings": 0 }]
+> ```
+
+### Pull requests
+
+```surql
+SELECT count() AS bot_with_embeddings
+FROM pull_request
+WHERE embedding != NONE AND author.is_bot = true
+GROUP ALL;
+-- Expected: [{ "bot_with_embeddings": 0 }]
+```
+
+> ```json
+> [{ "bot_with_embeddings": 0 }]
+> ```
+
+### Discussions
+
+```surql
+SELECT count() AS bot_with_embeddings
+FROM discussion
+WHERE embedding != NONE AND author.is_bot = true
+GROUP ALL;
+-- Expected: [{ "bot_with_embeddings": 0 }]
+```
+
+> ```json
+> [{ "bot_with_embeddings": 0 }]
+> ```
+
+### Comments
+
+```surql
+SELECT count() AS bot_with_embeddings
+FROM comment
+WHERE embedding != NONE AND author.is_bot = true
+GROUP ALL;
+-- Expected: [{ "bot_with_embeddings": 0 }]
+```
+
+> ```json
+> [{ "bot_with_embeddings": 0 }]
+> ```
+
+_The `user.is_bot` flag is set at ingest time from GitHub's `User.type == "Bot"` field and the `[bot]` login suffix. The embed stage reads this flag and skips bot-authored items entirely._

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -2,11 +2,11 @@ export default function run(): void {
   console.log("Usage: tool <command>");
   console.log("");
   console.log("Commands:");
-  console.log("  add     Register a GitHub repo for mirroring (tool add owner/name)");
-  console.log("  sync    Sync a registered repo (tool sync owner/name)");
-  console.log("  list    List registered repos (tool list [--json])");
-  console.log("  remove  Unregister a repo (tool remove owner/name [--purge] [--yes])");
+  console.log("  add      Register a GitHub repo for mirroring (tool add owner/name)");
+  console.log("  sync     Sync a registered repo (tool sync owner/name)");
+  console.log("  list     List registered repos (tool list [--json])");
+  console.log("  remove   Unregister a repo (tool remove owner/name [--purge] [--yes])");
   console.log("  inspect  Inspect a mirrored repo snapshot (tool inspect owner/name [--json])");
-  console.log("  help    Show this help message");
+  console.log("  help     Show this help message");
   process.exit(0);
 }

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -6,6 +6,7 @@ export default function run(): void {
   console.log("  sync    Sync a registered repo (tool sync owner/name)");
   console.log("  list    List registered repos (tool list [--json])");
   console.log("  remove  Unregister a repo (tool remove owner/name [--purge] [--yes])");
+  console.log("  inspect  Inspect a mirrored repo snapshot (tool inspect owner/name [--json])");
   console.log("  help    Show this help message");
   process.exit(0);
 }

--- a/src/commands/inspect.test.ts
+++ b/src/commands/inspect.test.ts
@@ -1,0 +1,288 @@
+import { describe, it, expect, mock, spyOn } from "bun:test";
+import type { Surreal } from "surrealdb";
+import { StringRecordId } from "surrealdb";
+import { withTestDb } from "../test_utils/with_test_db.ts";
+
+let _testDb: Surreal;
+
+mock.module("../clients/surreal.ts", () => ({
+  withDb: (fn: (db: Surreal) => Promise<unknown>) => fn(_testDb),
+}));
+
+const { default: run } = await import("./inspect.ts");
+
+// ── Capture helpers ────────────────────────────────────────────────────────────
+
+function captureLog(fn: () => Promise<void>): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const lines: string[] = [];
+    const orig = console.log;
+    console.log = (...args: unknown[]) => lines.push(args.join(" "));
+    fn()
+      .then(() => {
+        console.log = orig;
+        resolve(lines.join("\n"));
+      })
+      .catch((err) => {
+        console.log = orig;
+        reject(err as Error);
+      });
+  });
+}
+
+function captureError(fn: () => Promise<void>): Promise<string> {
+  return new Promise((resolve) => {
+    const lines: string[] = [];
+    const orig = console.error;
+    console.error = (...args: unknown[]) => lines.push(args.join(" "));
+    fn()
+      .then(() => {
+        console.error = orig;
+        resolve(lines.join("\n"));
+      })
+      .catch(() => {
+        console.error = orig;
+        resolve(lines.join("\n"));
+      });
+  });
+}
+
+// ── Seed ───────────────────────────────────────────────────────────────────────
+
+async function seedInspect(db: Surreal): Promise<void> {
+  // org
+  await db.query(`
+    CREATE org:inspectorg CONTENT {
+      github_node_id: 'U_inspect',
+      github_url: 'https://github.com/testorg',
+      login: 'testorg',
+      name: 'Test Org',
+      kind: 'Organization',
+      created_at: time::now(),
+      updated_at: time::now(),
+      deleted_at: NONE
+    }
+  `);
+
+  // repo (with registered_at)
+  await db.query(`
+    CREATE repo:inspectrepo CONTENT {
+      github_node_id: 'R_inspect',
+      github_url: 'https://github.com/testorg/testrepo',
+      owner: org:inspectorg,
+      name: 'testrepo',
+      name_with_owner: 'testorg/testrepo',
+      description: NONE,
+      is_private: false,
+      registered_at: time::now(),
+      last_synced_at: NONE,
+      created_at: time::now(),
+      updated_at: time::now()
+    }
+  `);
+
+  // issue 1 — no embedding
+  const [issue1Rows] = await db.query<[Array<{ id: unknown }>]>(`
+    CREATE issue:inspect1 CONTENT {
+      github_node_id: 'I_inspect1',
+      github_url: 'https://github.com/testorg/testrepo/issues/1',
+      repo: repo:inspectrepo,
+      number: 1,
+      title: 'First Issue',
+      body: 'Some body',
+      state: 'OPEN',
+      state_reason: NONE,
+      author: NONE,
+      closed_at: NONE,
+      created_at: time::now(),
+      updated_at: time::now(),
+      deleted_at: NONE,
+      content_hash: NONE,
+      embedding: NONE
+    }
+  `);
+
+  // issue 2 — with embedding (768-dim)
+  const embedding = Array(768).fill(0.1);
+  await db.query(`
+    CREATE issue:inspect2 CONTENT {
+      github_node_id: 'I_inspect2',
+      github_url: 'https://github.com/testorg/testrepo/issues/2',
+      repo: repo:inspectrepo,
+      number: 2,
+      title: 'Second Issue',
+      body: 'Another body',
+      state: 'CLOSED',
+      state_reason: NONE,
+      author: NONE,
+      closed_at: time::now(),
+      created_at: time::now(),
+      updated_at: time::now(),
+      deleted_at: NONE,
+      content_hash: 'abc123',
+      embedding: $embedding
+    }
+  `, { embedding });
+
+  // pull_request 1
+  await db.query(`
+    CREATE pull_request:inspectpr CONTENT {
+      github_node_id: 'PR_inspect1',
+      github_url: 'https://github.com/testorg/testrepo/pull/10',
+      repo: repo:inspectrepo,
+      number: 10,
+      title: 'First PR',
+      body: NONE,
+      state: 'OPEN',
+      author: NONE,
+      merged_at: NONE,
+      closed_at: NONE,
+      created_at: time::now(),
+      updated_at: time::now(),
+      deleted_at: NONE,
+      content_hash: NONE,
+      embedding: NONE
+    }
+  `);
+
+  // label
+  await db.query(`
+    CREATE label:inspectlabel CONTENT {
+      github_node_id: 'LB_inspect1',
+      repo: repo:inspectrepo,
+      name: 'bug',
+      color: 'd73a4a',
+      description: NONE,
+      created_at: time::now(),
+      updated_at: time::now(),
+      deleted_at: NONE
+    }
+  `);
+
+  // has_label edge: issue1 → label
+  const issue1Ref = new StringRecordId(String(issue1Rows[0].id));
+  await db.query(
+    "RELATE $from->has_label->label:inspectlabel CONTENT { created_at: time::now() }",
+    { from: issue1Ref },
+  );
+
+  // comment (parent_issue = issue:inspect1)
+  await db.query(`
+    CREATE comment:inspectcomment CONTENT {
+      github_node_id: 'C_inspect1',
+      github_url: 'https://github.com/testorg/testrepo/issues/1#issuecomment-1',
+      parent_issue: issue:inspect1,
+      parent_pr: NONE,
+      parent_discussion: NONE,
+      parent_comment: NONE,
+      author: NONE,
+      body: 'A comment',
+      created_at: time::now(),
+      updated_at: time::now(),
+      deleted_at: NONE,
+      content_hash: NONE,
+      embedding: NONE
+    }
+  `);
+
+  // dangling_reference targeting this repo (dangling_incoming)
+  await db.query(`
+    CREATE dangling_reference CONTENT {
+      parent: issue:inspect1,
+      target_owner: 'testorg',
+      target_repo: 'testrepo',
+      target_number: 99,
+      ref_kind: 'references_ref',
+      detected_at: time::now()
+    }
+  `);
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
+
+describe("inspect command", () => {
+  it("--json on seeded repo returns correct snapshot shape", async () => {
+    await withTestDb(async (db) => {
+      _testDb = db;
+      await seedInspect(db);
+
+      const output = await captureLog(() => run(["testorg/testrepo", "--json"]));
+
+      const result = JSON.parse(output) as {
+        repo_meta: { name_with_owner: string };
+        node_counts: { issue: { total: number }; pull_request: { total: number } };
+        embed_coverage: { issue: { percent: number } };
+        dangling_sample: unknown[];
+        closes_summary: { closes_outgoing: number; dangling_outgoing: number; dangling_incoming: number };
+      };
+
+      expect(result.repo_meta.name_with_owner).toBe("testorg/testrepo");
+      expect(result.node_counts.issue.total).toBe(2);
+      expect(result.node_counts.pull_request.total).toBe(1);
+      expect(typeof result.embed_coverage.issue.percent).toBe("number");
+      expect(isNaN(result.embed_coverage.issue.percent)).toBe(false);
+      expect(result.embed_coverage.issue.percent).toBeGreaterThanOrEqual(0);
+      expect(Array.isArray(result.dangling_sample)).toBe(true);
+    });
+  });
+
+  it("no args exits 1 with usage error", async () => {
+    await withTestDb(async (db) => {
+      _testDb = db;
+
+      const exitSpy = spyOn(process, "exit").mockImplementation((_code?: number) => {
+        throw new Error("process.exit");
+      });
+
+      let errorOutput = "";
+      try {
+        errorOutput = await captureError(() => run([]));
+      } catch {
+        // process.exit throws
+      }
+
+      expect(exitSpy).toHaveBeenCalledWith(1);
+      expect(errorOutput).toContain("Usage");
+
+      exitSpy.mockRestore();
+    });
+  });
+
+  it("unregistered repo arg exits 1 with not found message", async () => {
+    await withTestDb(async (db) => {
+      _testDb = db;
+
+      const exitSpy = spyOn(process, "exit").mockImplementation((_code?: number) => {
+        throw new Error("process.exit");
+      });
+
+      let errorOutput = "";
+      try {
+        errorOutput = await captureError(() => run(["nobody/norepo"]));
+      } catch {
+        // process.exit throws
+      }
+
+      expect(exitSpy).toHaveBeenCalledWith(1);
+      expect(errorOutput).toContain("not found");
+
+      exitSpy.mockRestore();
+    });
+  });
+
+  it("human output shows labeled sections and Warning for 0% coverage", async () => {
+    await withTestDb(async (db) => {
+      _testDb = db;
+      await seedInspect(db);
+
+      const output = await captureLog(() => run(["testorg/testrepo"]));
+
+      expect(output).toContain("== testorg/testrepo ==");
+      expect(output).toContain("-- Node counts --");
+      expect(output).toContain("-- Embed coverage --");
+      expect(output).toContain("-- Closes summary --");
+      // No embeddings set for PR/comment, so expect warning
+      expect(output).toContain("! Warning");
+    });
+  });
+});

--- a/src/commands/inspect.ts
+++ b/src/commands/inspect.ts
@@ -1,0 +1,422 @@
+import { withDb } from "../clients/surreal.ts";
+import { StringRecordId } from "surrealdb";
+import type { Surreal } from "surrealdb";
+
+function formatDate(dt: unknown): string {
+  if (dt == null) return "(never)";
+  const date = dt instanceof Date ? dt : new Date(String(dt));
+  if (isNaN(date.getTime())) return "(never)";
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return (
+    `${date.getUTCFullYear()}-${pad(date.getUTCMonth() + 1)}-${pad(date.getUTCDate())}` +
+    ` ${pad(date.getUTCHours())}:${pad(date.getUTCMinutes())}:${pad(date.getUTCSeconds())}`
+  );
+}
+
+interface NodeCount {
+  total: number;
+  tombstoned: number;
+}
+
+interface EmbedCoverage {
+  total: number;
+  bot_authored: number;
+  eligible: number;
+  embedded: number;
+  percent: number;
+}
+
+interface TopReferenced {
+  id: string;
+  number: number;
+  title: string;
+  ref_count: number;
+}
+
+interface ClosesSummary {
+  closes_outgoing: number;
+  dangling_outgoing: number;
+  dangling_incoming: number;
+}
+
+interface DanglingSample {
+  target_owner: string;
+  target_repo: string;
+  target_number: number;
+  ref_kind: string;
+}
+
+interface RecentUpdate {
+  kind: string;
+  number: number | null;
+  title: string;
+  updated_at: unknown;
+}
+
+interface Snapshot {
+  repo_meta: { name_with_owner: string; registered_at: unknown; last_synced_at: unknown };
+  node_counts: Record<string, NodeCount>;
+  embed_coverage: Record<string, EmbedCoverage>;
+  top_referenced: TopReferenced[];
+  closes_summary: ClosesSummary;
+  dangling_sample: DanglingSample[];
+  recent_updates: RecentUpdate[];
+}
+
+type CommentRow = {
+  id: unknown;
+  parent_issue: unknown;
+  parent_pr: unknown;
+  parent_discussion: unknown;
+  deleted_at: unknown;
+  embedding: unknown;
+  author: unknown;
+  updated_at: unknown;
+};
+
+async function fetchRows<T>(
+  db: Surreal,
+  query: string,
+  params?: Record<string, unknown>,
+): Promise<T[]> {
+  const [result] = await db.query<[T[]]>(query, params ?? {});
+  return result;
+}
+
+async function buildSnapshot(
+  db: Surreal,
+  repoRow: { id: unknown; name_with_owner: string; registered_at: unknown; last_synced_at: unknown },
+  owner: string,
+  name: string,
+): Promise<Snapshot> {
+  const repoRef = new StringRecordId(String(repoRow.id));
+
+  // Collect entity IDs for this repo — used to scope comments without dot traversal
+  const issueIdRows = await fetchRows<{ id: unknown }>(
+    db, "SELECT id FROM issue WHERE repo = $repoRef", { repoRef },
+  );
+  const prIdRows = await fetchRows<{ id: unknown }>(
+    db, "SELECT id FROM pull_request WHERE repo = $repoRef", { repoRef },
+  );
+  const discIdRows = await fetchRows<{ id: unknown }>(
+    db, "SELECT id FROM discussion WHERE repo = $repoRef", { repoRef },
+  );
+
+  const issueIds = new Set(issueIdRows.map((r) => String(r.id)));
+  const prIds = new Set(prIdRows.map((r) => String(r.id)));
+  const discIds = new Set(discIdRows.map((r) => String(r.id)));
+  const allEntityIds = new Set([...issueIds, ...prIds, ...discIds]);
+
+  // Fetch all comments once; filter in JS to avoid WASM dot-traversal limitations
+  const allComments = await fetchRows<CommentRow>(
+    db,
+    "SELECT id, parent_issue, parent_pr, parent_discussion, deleted_at, embedding, author, updated_at FROM comment",
+  );
+  const repoComments = allComments.filter(
+    (c) =>
+      (c.parent_issue && issueIds.has(String(c.parent_issue))) ||
+      (c.parent_pr && prIds.has(String(c.parent_pr))) ||
+      (c.parent_discussion && discIds.has(String(c.parent_discussion))),
+  );
+
+  // ── Node counts ────────────────────────────────────────────────────────────
+  const node_counts: Record<string, NodeCount> = {};
+
+  for (const type of ["issue", "pull_request", "discussion", "commit", "label"] as const) {
+    const all = await fetchRows<unknown>(
+      db, `SELECT id FROM ${type} WHERE repo = $repoRef`, { repoRef },
+    );
+    const tombstoned = await fetchRows<unknown>(
+      db, `SELECT id FROM ${type} WHERE repo = $repoRef AND deleted_at != NONE`, { repoRef },
+    );
+    node_counts[type] = { total: all.length, tombstoned: tombstoned.length };
+  }
+
+  node_counts["comment"] = {
+    total: repoComments.length,
+    tombstoned: repoComments.filter((c) => c.deleted_at != null).length,
+  };
+
+  // ── Embed coverage ─────────────────────────────────────────────────────────
+  const embed_coverage: Record<string, EmbedCoverage> = {};
+
+  for (const type of ["issue", "pull_request", "discussion"] as const) {
+    const rows = await fetchRows<{ author: unknown; embedding: unknown }>(
+      db,
+      `SELECT author, embedding FROM ${type} WHERE repo = $repoRef AND deleted_at = NONE`,
+      { repoRef },
+    );
+    const total = rows.length;
+    let bot_authored = 0;
+    try {
+      // Try dot traversal; may fail in WASM
+      const botRows = await fetchRows<unknown>(
+        db,
+        `SELECT id FROM ${type} WHERE repo = $repoRef AND deleted_at = NONE AND author.is_bot = true`,
+        { repoRef },
+      );
+      bot_authored = botRows.length;
+    } catch {
+      bot_authored = rows.filter((r) => (r.author as Record<string, unknown>)?.is_bot === true).length;
+    }
+    const eligible = total - bot_authored;
+    const embedded = rows.filter(
+      (r) => r.embedding != null && (r.author as Record<string, unknown>)?.is_bot !== true,
+    ).length;
+    const percent = eligible > 0 ? Math.round((embedded / eligible) * 100) : 0;
+    embed_coverage[type] = { total, bot_authored, eligible, embedded, percent };
+  }
+
+  {
+    const nonTombstoned = repoComments.filter((c) => c.deleted_at == null);
+    const total = nonTombstoned.length;
+    const bot_authored = nonTombstoned.filter(
+      (c) => (c.author as Record<string, unknown>)?.is_bot === true,
+    ).length;
+    const eligible = total - bot_authored;
+    const embedded = nonTombstoned.filter(
+      (c) => c.embedding != null && (c.author as Record<string, unknown>)?.is_bot !== true,
+    ).length;
+    const percent = eligible > 0 ? Math.round((embedded / eligible) * 100) : 0;
+    embed_coverage["comment"] = { total, bot_authored, eligible, embedded, percent };
+  }
+
+  // ── Top referenced ─────────────────────────────────────────────────────────
+  let top_referenced: TopReferenced[] = [];
+  try {
+    const topRows = await fetchRows<{
+      id: unknown;
+      number: number;
+      title: string;
+      ref_count: number;
+    }>(
+      db,
+      `SELECT id, number, title, array::len(<-references_ref) AS ref_count
+       FROM issue, pull_request
+       WHERE repo = $repoRef AND deleted_at = NONE
+       ORDER BY ref_count DESC LIMIT 5`,
+      { repoRef },
+    );
+    top_referenced = topRows.map((r) => ({
+      id: String(r.id),
+      number: r.number,
+      title: r.title,
+      ref_count: r.ref_count ?? 0,
+    }));
+  } catch {
+    // Fallback: count edges per node individually
+    const allNodes = await fetchRows<{ id: unknown; number: number; title: string }>(
+      db,
+      `SELECT id, number, title FROM issue, pull_request WHERE repo = $repoRef AND deleted_at = NONE`,
+      { repoRef },
+    );
+    const withCounts = await Promise.all(
+      allNodes.map(async (node) => {
+        const nodeRef = new StringRecordId(String(node.id));
+        const edgeRows = await fetchRows<unknown>(
+          db, "SELECT id FROM references_ref WHERE out = $nodeRef", { nodeRef },
+        );
+        return { id: String(node.id), number: node.number, title: node.title, ref_count: edgeRows.length };
+      }),
+    );
+    top_referenced = withCounts.sort((a, b) => b.ref_count - a.ref_count).slice(0, 5);
+  }
+
+  // ── Closes summary ─────────────────────────────────────────────────────────
+  let closes_outgoing = 0;
+  try {
+    const closeRows = await fetchRows<unknown>(
+      db, "SELECT id FROM closes WHERE in.repo = $repoRef", { repoRef },
+    );
+    closes_outgoing = closeRows.length;
+  } catch {
+    // Fallback: count per PR
+    for (const prId of prIds) {
+      const prRef = new StringRecordId(prId);
+      const edgeRows = await fetchRows<unknown>(
+        db, "SELECT id FROM closes WHERE in = $prRef", { prRef },
+      );
+      closes_outgoing += edgeRows.length;
+    }
+  }
+
+  let dangling_outgoing = 0;
+  try {
+    const danglingRows = await fetchRows<unknown>(
+      db, "SELECT id FROM dangling_reference WHERE parent.repo = $repoRef", { repoRef },
+    );
+    dangling_outgoing = danglingRows.length;
+  } catch {
+    // Fallback: filter all dangling rows by parent membership in JS
+    const allDangling = await fetchRows<{ parent: unknown }>(
+      db, "SELECT parent FROM dangling_reference",
+    );
+    dangling_outgoing = allDangling.filter((r) => allEntityIds.has(String(r.parent))).length;
+  }
+
+  const danglingIncomingRows = await fetchRows<unknown>(
+    db,
+    "SELECT id FROM dangling_reference WHERE target_owner = $owner AND target_repo = $name",
+    { owner, name },
+  );
+  const dangling_incoming = danglingIncomingRows.length;
+
+  // ── Dangling sample ────────────────────────────────────────────────────────
+  const dangling_sample = await fetchRows<DanglingSample>(
+    db,
+    "SELECT target_owner, target_repo, target_number, ref_kind FROM dangling_reference WHERE target_owner = $owner AND target_repo = $name LIMIT 5",
+    { owner, name },
+  );
+
+  // ── Recent updates ─────────────────────────────────────────────────────────
+  const allUpdates: RecentUpdate[] = [];
+
+  for (const kind of ["issue", "pull_request", "discussion"] as const) {
+    const rows = await fetchRows<{ number: number; title: string; updated_at: unknown }>(
+      db,
+      `SELECT number, title, updated_at FROM ${kind} WHERE repo = $repoRef AND deleted_at = NONE ORDER BY updated_at DESC LIMIT 5`,
+      { repoRef },
+    );
+    for (const r of rows) {
+      allUpdates.push({ kind, number: r.number, title: r.title, updated_at: r.updated_at });
+    }
+  }
+
+  // Use already-fetched repoComments for recent comment updates
+  const recentComments = repoComments
+    .filter((c) => c.deleted_at == null)
+    .sort((a, b) => {
+      const aTime = a.updated_at ? new Date(String(a.updated_at)).getTime() : 0;
+      const bTime = b.updated_at ? new Date(String(b.updated_at)).getTime() : 0;
+      return bTime - aTime;
+    })
+    .slice(0, 5);
+  for (const c of recentComments) {
+    allUpdates.push({ kind: "comment", number: null, title: String(c.id), updated_at: c.updated_at });
+  }
+
+  const recent_updates = allUpdates
+    .sort((a, b) => {
+      const aTime = a.updated_at ? new Date(String(a.updated_at)).getTime() : 0;
+      const bTime = b.updated_at ? new Date(String(b.updated_at)).getTime() : 0;
+      return bTime - aTime;
+    })
+    .slice(0, 5);
+
+  return {
+    repo_meta: {
+      name_with_owner: repoRow.name_with_owner,
+      registered_at: repoRow.registered_at,
+      last_synced_at: repoRow.last_synced_at,
+    },
+    node_counts,
+    embed_coverage,
+    top_referenced,
+    closes_summary: { closes_outgoing, dangling_outgoing, dangling_incoming },
+    dangling_sample,
+    recent_updates,
+  };
+}
+
+function renderHuman(snapshot: Snapshot, nwo: string): void {
+  const { repo_meta, node_counts, embed_coverage, top_referenced, closes_summary, dangling_sample, recent_updates } = snapshot;
+
+  console.log(`\n== ${repo_meta.name_with_owner} ==`);
+  console.log(
+    `Registered: ${formatDate(repo_meta.registered_at)}  Last synced: ${formatDate(repo_meta.last_synced_at)}`,
+  );
+
+  if (repo_meta.last_synced_at == null) {
+    console.log(`! (repo has not been synced — run \`tool sync ${nwo}\`)`);
+  }
+
+  console.log("\n-- Node counts --");
+  for (const type of ["issue", "pull_request", "discussion", "comment", "commit", "label"]) {
+    const nc = node_counts[type];
+    console.log(`  ${type.padEnd(14)}: ${nc.total} total, ${nc.tombstoned} tombstoned`);
+  }
+
+  console.log("\n-- Embed coverage --");
+  let allZero = true;
+  for (const type of ["issue", "pull_request", "discussion", "comment"]) {
+    const ec = embed_coverage[type];
+    console.log(`  ${type.padEnd(14)}: eligible=${ec.eligible}  embedded=${ec.embedded}  (${ec.percent}%)`);
+    if (ec.percent === 0 && ec.eligible > 0) {
+      console.log(`  ! Warning: ${type} has 0% embed coverage`);
+    }
+    if (ec.percent > 0) allZero = false;
+  }
+  if (allZero && repo_meta.last_synced_at != null) {
+    console.log(`! (no embeddings yet — run \`tool embed ${nwo}\`)`);
+  }
+
+  console.log("\n-- Top referenced --");
+  if (top_referenced.length === 0) {
+    console.log("  (none)");
+  } else {
+    for (const ref of top_referenced) {
+      console.log(`  #${ref.number} ${ref.title} (${ref.ref_count} refs)`);
+    }
+  }
+
+  console.log("\n-- Closes summary --");
+  console.log(
+    `  closes_outgoing: ${closes_summary.closes_outgoing}  dangling_outgoing: ${closes_summary.dangling_outgoing}  dangling_incoming: ${closes_summary.dangling_incoming}`,
+  );
+
+  console.log("\n-- Dangling sample --");
+  if (dangling_sample.length === 0) {
+    console.log("  (none)");
+  } else {
+    for (const d of dangling_sample) {
+      console.log(`  ${d.target_owner}/${d.target_repo}#${d.target_number} (${d.ref_kind})`);
+    }
+  }
+
+  console.log("\n-- Recent updates --");
+  if (recent_updates.length === 0) {
+    console.log("  (none)");
+  } else {
+    for (const r of recent_updates) {
+      const label = r.number != null ? `#${r.number} ${r.title}` : r.title;
+      console.log(`  [${r.kind}] ${label} — ${formatDate(r.updated_at)}`);
+    }
+  }
+}
+
+export default async function run(args: string[]): Promise<void> {
+  const nwo = args.find((a) => !a.startsWith("--"));
+  const json = args.includes("--json");
+
+  if (!nwo || !nwo.includes("/")) {
+    console.error("✗ Usage: tool inspect <owner/name> [--json]");
+    process.exit(1);
+  }
+
+  const [owner, name] = nwo.split("/");
+
+  await withDb(async (db) => {
+    const [repoRows] = await db.query<
+      [Array<{ id: unknown; name_with_owner: string; registered_at: unknown; last_synced_at: unknown }>]
+    >(
+      "SELECT id, name_with_owner, registered_at, last_synced_at FROM repo WHERE name_with_owner = $nwo AND registered_at != NONE",
+      { nwo },
+    );
+
+    if (repoRows.length === 0) {
+      console.error(
+        `✗ Repo '${nwo}' not found — register it first with \`tool add <owner/name>\``,
+      );
+      process.exit(1);
+    }
+
+    const snapshot = await buildSnapshot(db, repoRows[0], owner, name);
+
+    if (json) {
+      console.log(JSON.stringify(snapshot));
+      return;
+    }
+
+    renderHuman(snapshot, nwo);
+  });
+}


### PR DESCRIPTION
## Summary

Closes the milestone with two artifacts:

- **`tool inspect <owner/name>`** (`src/commands/inspect.ts`) — read-only command that prints a structured snapshot of one mirrored repo: per-type node counts, embed coverage, top-5 referenced issues/PRs, closes summary, dangling-reference sample, recent updates. Supports `--json` for agent consumers (per the read-style-commands principle in `ARCHITECTURE.md`).
- **`QUERIES.md`** at repo root — copy-paste-runnable SurrealQL examples for the common access patterns: counts, joins via record link, vector similarity, cross-references, recent activity, bot policy verification.

Plus help-text update and 5 new tests covering the inspect command.

## Test plan

- [x] `bun run typecheck` — clean.
- [x] `bun test` — 83/83 pass across 14 files.
- [x] Inspect tests: pre-seed in-memory DB with a registered repo + issues / PRs / labels / comments / dangling refs; run `inspect`; assert JSON keys (`repo_meta`, `node_counts`, `embed_coverage`, `top_referenced`, `dangling_sample`, `recent_updates`).
- [x] Error path: unregistered repo errors loudly with hint.
- [ ] **Manual end-to-end** against `lfnovo/esperanto` after `tool sync` lands data — for the milestone PR description.
- [ ] `bun run smoke:*` (manual; unaffected).

## Notes

- **Embed coverage formula**: `embedded = eligible items WHERE embedding != NONE`. Doesn't yet check `embedded_content_hash` (introduced by #11; field doesn't exist in the schema at this PR's time). Refresh follow-up after #11 lands.
- **Comment scoping**: via the three nullable parent fields (`parent_issue` / `parent_pr` / `parent_discussion`) — matches current schema; no union refactor.
- **`QUERIES.md` examples are tested against the schema only** at this PR's time. Manual verification against a synced `lfnovo/esperanto` mirror happens after `tool sync` runs end-to-end.
- Small polish on top of harny's output: aligned the `inspect` line in `help.ts` so column widths are consistent across all 6 commands (one-character whitespace fix).

## Out of scope

- Multi-repo inspect.
- Time-series inspection (history of counts).
- Performance / vector index tuning.
- `embedded_content_hash` integration (after #11).
- Live data validation of `QUERIES.md` examples (after `tool sync` produces real data).

Closes #12


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a read-only `tool inspect <owner/name>` command to print a structured snapshot of a mirrored repo, plus `QUERIES.md` with runnable SurrealQL examples. This helps verify data health and supports agents via `--json`.

- **New Features**
  - `tool inspect`: shows per-type node counts, embed coverage, top-5 referenced issues/PRs, closes summary, dangling-reference sample, and recent updates; supports `--json`.
  - `QUERIES.md`: copy-paste SurrealQL for counts, record-link joins, vector similarity (HNSW), cross-references (`closes`, dangling), recent activity, and bot policy checks.
  - Help text lists `inspect` and aligns columns; added tests for JSON shape, human output, and error paths.

<sup>Written for commit 0ad95b28c15f65241d5e752842366527c6dd7fec. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

