### PR TITLE
feat: tool embed — Ollama embed pass with skip-and-continue

### DIFF
--- a/schemas.surrealql
+++ b/schemas.surrealql
@@ -93,8 +93,9 @@ DEFINE FIELD IF NOT EXISTS created_at     ON TABLE issue TYPE datetime;
 DEFINE FIELD IF NOT EXISTS updated_at     ON TABLE issue TYPE datetime;
 DEFINE FIELD IF NOT EXISTS deleted_at     ON TABLE issue TYPE option<datetime>;
 -- Embedding pipeline fields
-DEFINE FIELD IF NOT EXISTS content_hash   ON TABLE issue TYPE option<string>;
-DEFINE FIELD IF NOT EXISTS embedding      ON TABLE issue TYPE option<array<float, 768>>;
+DEFINE FIELD IF NOT EXISTS content_hash          ON TABLE issue TYPE option<string>;
+DEFINE FIELD IF NOT EXISTS embedding             ON TABLE issue TYPE option<array<float, 768>>;
+DEFINE FIELD IF NOT EXISTS embedded_content_hash ON TABLE issue TYPE option<string>;
 
 DEFINE INDEX IF NOT EXISTS issue_node_id_uniq ON TABLE issue FIELDS github_node_id UNIQUE;
 DEFINE INDEX IF NOT EXISTS issue_repo_number  ON TABLE issue FIELDS repo, number UNIQUE;
@@ -119,8 +120,9 @@ DEFINE FIELD IF NOT EXISTS closed_at      ON TABLE pull_request TYPE option<date
 DEFINE FIELD IF NOT EXISTS created_at     ON TABLE pull_request TYPE datetime;
 DEFINE FIELD IF NOT EXISTS updated_at     ON TABLE pull_request TYPE datetime;
 DEFINE FIELD IF NOT EXISTS deleted_at     ON TABLE pull_request TYPE option<datetime>;
-DEFINE FIELD IF NOT EXISTS content_hash   ON TABLE pull_request TYPE option<string>;
-DEFINE FIELD IF NOT EXISTS embedding      ON TABLE pull_request TYPE option<array<float, 768>>;
+DEFINE FIELD IF NOT EXISTS content_hash          ON TABLE pull_request TYPE option<string>;
+DEFINE FIELD IF NOT EXISTS embedding             ON TABLE pull_request TYPE option<array<float, 768>>;
+DEFINE FIELD IF NOT EXISTS embedded_content_hash ON TABLE pull_request TYPE option<string>;
 
 DEFINE INDEX IF NOT EXISTS pr_node_id_uniq ON TABLE pull_request FIELDS github_node_id UNIQUE;
 DEFINE INDEX IF NOT EXISTS pr_repo_number  ON TABLE pull_request FIELDS repo, number UNIQUE;
@@ -144,8 +146,9 @@ DEFINE FIELD IF NOT EXISTS answer_chosen_at ON TABLE discussion TYPE option<date
 DEFINE FIELD IF NOT EXISTS created_at       ON TABLE discussion TYPE datetime;
 DEFINE FIELD IF NOT EXISTS updated_at       ON TABLE discussion TYPE datetime;
 DEFINE FIELD IF NOT EXISTS deleted_at       ON TABLE discussion TYPE option<datetime>;
-DEFINE FIELD IF NOT EXISTS content_hash     ON TABLE discussion TYPE option<string>;
-DEFINE FIELD IF NOT EXISTS embedding        ON TABLE discussion TYPE option<array<float, 768>>;
+DEFINE FIELD IF NOT EXISTS content_hash          ON TABLE discussion TYPE option<string>;
+DEFINE FIELD IF NOT EXISTS embedding             ON TABLE discussion TYPE option<array<float, 768>>;
+DEFINE FIELD IF NOT EXISTS embedded_content_hash ON TABLE discussion TYPE option<string>;
 
 DEFINE INDEX IF NOT EXISTS disc_node_id_uniq ON TABLE discussion FIELDS github_node_id UNIQUE;
 DEFINE INDEX IF NOT EXISTS disc_repo_number  ON TABLE discussion FIELDS repo, number UNIQUE;
@@ -168,8 +171,9 @@ DEFINE FIELD IF NOT EXISTS body              ON TABLE comment TYPE string;
 DEFINE FIELD IF NOT EXISTS created_at        ON TABLE comment TYPE datetime;
 DEFINE FIELD IF NOT EXISTS updated_at        ON TABLE comment TYPE datetime;
 DEFINE FIELD IF NOT EXISTS deleted_at        ON TABLE comment TYPE option<datetime>;
-DEFINE FIELD IF NOT EXISTS content_hash      ON TABLE comment TYPE option<string>;
-DEFINE FIELD IF NOT EXISTS embedding         ON TABLE comment TYPE option<array<float, 768>>;
+DEFINE FIELD IF NOT EXISTS content_hash          ON TABLE comment TYPE option<string>;
+DEFINE FIELD IF NOT EXISTS embedding             ON TABLE comment TYPE option<array<float, 768>>;
+DEFINE FIELD IF NOT EXISTS embedded_content_hash ON TABLE comment TYPE option<string>;
 
 DEFINE INDEX IF NOT EXISTS comment_node_id_uniq ON TABLE comment FIELDS github_node_id UNIQUE;
 DEFINE INDEX IF NOT EXISTS comment_embedding_hnsw

--- a/src/commands/embed.test.ts
+++ b/src/commands/embed.test.ts
@@ -1,0 +1,458 @@
+import { describe, it, expect, mock } from "bun:test";
+import type { Surreal } from "surrealdb";
+import { StringRecordId } from "surrealdb";
+import { withTestDb } from "../test_utils/with_test_db.ts";
+
+let testDb: Surreal | null = null;
+let embedManyCallCount = 0;
+let embedManyImpl: (texts: string[]) => Promise<number[][]> = async (texts) =>
+  texts.map(() => new Array(768).fill(0.1));
+let embedProbeImpl: () => Promise<number[]> = async () => new Array(768).fill(0.1);
+
+mock.module("../clients/ollama.ts", () => ({
+  embed: (_text: string) => embedProbeImpl(),
+  embedMany: (texts: string[]) => {
+    embedManyCallCount++;
+    return embedManyImpl(texts);
+  },
+}));
+
+mock.module("../clients/surreal.ts", () => ({
+  withDb: (fn: (db: Surreal) => Promise<unknown>) => fn(testDb!),
+}));
+
+const { default: run } = await import("./embed.ts");
+
+async function runCapturingExit(
+  fn: () => Promise<void>,
+): Promise<{ exitCode: number | undefined }> {
+  const orig = process.exit;
+  let exitCode: number | undefined;
+  (process as any).exit = (code?: number) => {
+    exitCode = code;
+    throw new Error(`__exit__${code}`);
+  };
+  try {
+    await fn();
+  } catch (e) {
+    if (!(e instanceof Error && e.message.startsWith("__exit__"))) {
+      (process as any).exit = orig;
+      throw e;
+    }
+  } finally {
+    (process as any).exit = orig;
+  }
+  return { exitCode };
+}
+
+async function seedRepoAndOrg(db: Surreal, suffix: string) {
+  const [orgRows] = await db.query<[Array<{ id: unknown }>]>(
+    `CREATE org CONTENT {
+      github_node_id: $gid,
+      github_url: 'https://github.com/testorg',
+      login: $login,
+      name: NONE,
+      kind: 'Organization',
+      created_at: time::now(),
+      updated_at: time::now(),
+      deleted_at: NONE
+    }`,
+    { gid: `ORG_${suffix}`, login: `testorg_${suffix}` },
+  );
+  const orgId = orgRows[0].id;
+
+  const nwo = `testorg_${suffix}/test-repo`;
+  const [repoRows] = await db.query<[Array<{ id: unknown }>]>(
+    `CREATE repo CONTENT {
+      github_node_id: $gid,
+      github_url: 'https://github.com/testorg/test-repo',
+      name: 'test-repo',
+      name_with_owner: $nwo,
+      description: NONE,
+      is_private: false,
+      owner: $owner,
+      created_at: time::now(),
+      updated_at: time::now(),
+      registered_at: time::now()
+    }`,
+    { gid: `REPO_${suffix}`, nwo, owner: orgId },
+  );
+  return { orgId, repoId: repoRows[0].id, nwo };
+}
+
+describe("embed command — happy path", () => {
+  it("embeds 2 non-bot issues and sets embedding + embedded_content_hash", async () => {
+    await withTestDb(async (db) => {
+      testDb = db;
+      embedManyCallCount = 0;
+      embedManyImpl = async (texts) => texts.map(() => new Array(768).fill(0.5));
+      embedProbeImpl = async () => new Array(768).fill(0.1);
+
+      const { repoId, nwo } = await seedRepoAndOrg(db, "HP");
+      const repoRef = new StringRecordId(String(repoId));
+
+      await db.query(
+        `CREATE issue CONTENT {
+          github_node_id: 'I_HP_1',
+          github_url: 'u',
+          repo: $repo,
+          number: 1,
+          title: 'Issue 1',
+          body: 'Body 1',
+          state: 'OPEN',
+          author: NONE,
+          created_at: time::now(),
+          updated_at: time::now(),
+          deleted_at: NONE,
+          content_hash: 'hash1',
+          embedding: NONE,
+          embedded_content_hash: NONE
+        }`,
+        { repo: repoRef },
+      );
+      await db.query(
+        `CREATE issue CONTENT {
+          github_node_id: 'I_HP_2',
+          github_url: 'u',
+          repo: $repo,
+          number: 2,
+          title: 'Issue 2',
+          body: 'Body 2',
+          state: 'OPEN',
+          author: NONE,
+          created_at: time::now(),
+          updated_at: time::now(),
+          deleted_at: NONE,
+          content_hash: 'hash2',
+          embedding: NONE,
+          embedded_content_hash: NONE
+        }`,
+        { repo: repoRef },
+      );
+
+      await run([nwo]);
+
+      const [issues] = await db.query<
+        [Array<{ github_node_id: string; embedding: unknown; embedded_content_hash: string }>]
+      >("SELECT github_node_id, embedding, embedded_content_hash FROM issue");
+
+      const i1 = issues.find((i) => i.github_node_id === "I_HP_1")!;
+      const i2 = issues.find((i) => i.github_node_id === "I_HP_2")!;
+      expect(i1.embedding).not.toBeNull();
+      expect(i1.embedding).not.toBeUndefined();
+      expect(i1.embedded_content_hash).toBe("hash1");
+      expect(i2.embedding).not.toBeNull();
+      expect(i2.embedding).not.toBeUndefined();
+      expect(i2.embedded_content_hash).toBe("hash2");
+    });
+    testDb = null;
+  });
+});
+
+describe("embed command — bot skip", () => {
+  it("does not embed bot-authored issue", async () => {
+    await withTestDb(async (db) => {
+      testDb = db;
+      embedManyCallCount = 0;
+      embedManyImpl = async (texts) => texts.map(() => new Array(768).fill(0.5));
+      embedProbeImpl = async () => new Array(768).fill(0.1);
+
+      const { repoId, nwo } = await seedRepoAndOrg(db, "BS");
+      const repoRef = new StringRecordId(String(repoId));
+
+      const [userRows] = await db.query<[Array<{ id: unknown }>]>(
+        `CREATE user CONTENT {
+          github_node_id: 'BOT_BS_1',
+          github_url: 'u',
+          login: 'bot-user',
+          name: NONE,
+          is_bot: true,
+          created_at: time::now(),
+          updated_at: time::now(),
+          deleted_at: NONE
+        }`,
+      );
+      const botId = userRows[0].id;
+
+      await db.query(
+        `CREATE issue CONTENT {
+          github_node_id: 'I_BS_1',
+          github_url: 'u',
+          repo: $repo,
+          number: 1,
+          title: 'Bot Issue',
+          body: 'body',
+          state: 'OPEN',
+          author: $author,
+          created_at: time::now(),
+          updated_at: time::now(),
+          deleted_at: NONE,
+          content_hash: 'bhash',
+          embedding: NONE,
+          embedded_content_hash: NONE
+        }`,
+        { repo: repoRef, author: new StringRecordId(String(botId)) },
+      );
+
+      await run([nwo]);
+
+      const [[issue]] = await db.query<[[{ embedding: unknown }]]>(
+        "SELECT embedding FROM issue WHERE github_node_id = 'I_BS_1'",
+      );
+      expect(issue.embedding == null).toBe(true);
+    });
+    testDb = null;
+  });
+});
+
+describe("embed command — up-to-date skip", () => {
+  it("does not call embedMany for issue with matching embedded_content_hash", async () => {
+    await withTestDb(async (db) => {
+      testDb = db;
+      embedManyCallCount = 0;
+      embedManyImpl = async (texts) => texts.map(() => new Array(768).fill(0.5));
+      embedProbeImpl = async () => new Array(768).fill(0.1);
+
+      const { repoId, nwo } = await seedRepoAndOrg(db, "UT");
+      const repoRef = new StringRecordId(String(repoId));
+
+      await db.query(
+        `CREATE issue CONTENT {
+          github_node_id: 'I_UT_1',
+          github_url: 'u',
+          repo: $repo,
+          number: 1,
+          title: 'Up-to-date',
+          body: 'body',
+          state: 'OPEN',
+          author: NONE,
+          created_at: time::now(),
+          updated_at: time::now(),
+          deleted_at: NONE,
+          content_hash: 'same_hash',
+          embedding: $embedding,
+          embedded_content_hash: 'same_hash'
+        }`,
+        { repo: repoRef, embedding: new Array(768).fill(0.5) },
+      );
+
+      await run([nwo]);
+
+      expect(embedManyCallCount).toBe(0);
+    });
+    testDb = null;
+  });
+});
+
+describe("embed command — re-embed on content change", () => {
+  it("re-embeds issue with stale embedded_content_hash", async () => {
+    await withTestDb(async (db) => {
+      testDb = db;
+      embedManyCallCount = 0;
+      embedManyImpl = async (texts) => texts.map(() => new Array(768).fill(0.9));
+      embedProbeImpl = async () => new Array(768).fill(0.1);
+
+      const { repoId, nwo } = await seedRepoAndOrg(db, "RE");
+      const repoRef = new StringRecordId(String(repoId));
+
+      await db.query(
+        `CREATE issue CONTENT {
+          github_node_id: 'I_RE_1',
+          github_url: 'u',
+          repo: $repo,
+          number: 1,
+          title: 'Stale',
+          body: 'body',
+          state: 'OPEN',
+          author: NONE,
+          created_at: time::now(),
+          updated_at: time::now(),
+          deleted_at: NONE,
+          content_hash: 'new_hash',
+          embedding: $embedding,
+          embedded_content_hash: 'old_hash'
+        }`,
+        { repo: repoRef, embedding: new Array(768).fill(0.1) },
+      );
+
+      await run([nwo]);
+
+      const [[issue]] = await db.query<
+        [[{ embedded_content_hash: string; embedding: number[] }]]
+      >("SELECT embedded_content_hash, embedding FROM issue WHERE github_node_id = 'I_RE_1'");
+
+      expect(issue.embedded_content_hash).toBe("new_hash");
+      expect(issue.embedding).not.toBeNull();
+      expect((issue.embedding as number[])[0]).toBeCloseTo(0.9, 5);
+    });
+    testDb = null;
+  });
+});
+
+describe("embed command — author-null embeds", () => {
+  it("embeds issue with NONE author", async () => {
+    await withTestDb(async (db) => {
+      testDb = db;
+      embedManyCallCount = 0;
+      embedManyImpl = async (texts) => texts.map(() => new Array(768).fill(0.5));
+      embedProbeImpl = async () => new Array(768).fill(0.1);
+
+      const { repoId, nwo } = await seedRepoAndOrg(db, "AN");
+      const repoRef = new StringRecordId(String(repoId));
+
+      await db.query(
+        `CREATE issue CONTENT {
+          github_node_id: 'I_AN_1',
+          github_url: 'u',
+          repo: $repo,
+          number: 1,
+          title: 'No Author',
+          body: 'body',
+          state: 'OPEN',
+          author: NONE,
+          created_at: time::now(),
+          updated_at: time::now(),
+          deleted_at: NONE,
+          content_hash: 'hash_a',
+          embedding: NONE,
+          embedded_content_hash: NONE
+        }`,
+        { repo: repoRef },
+      );
+
+      await run([nwo]);
+
+      const [[issue]] = await db.query<[[{ embedding: unknown }]]>(
+        "SELECT embedding FROM issue WHERE github_node_id = 'I_AN_1'",
+      );
+      expect(issue.embedding).not.toBeNull();
+      expect(issue.embedding).not.toBeUndefined();
+    });
+    testDb = null;
+  });
+});
+
+describe("embed command — Ollama probe failure", () => {
+  it("exits non-zero and writes no embeddings when Ollama is unreachable", async () => {
+    await withTestDb(async (db) => {
+      testDb = db;
+      embedManyCallCount = 0;
+      embedProbeImpl = async () => {
+        throw new Error("connection refused");
+      };
+      embedManyImpl = async (texts) => texts.map(() => new Array(768).fill(0.5));
+
+      const { repoId, nwo } = await seedRepoAndOrg(db, "OF");
+      const repoRef = new StringRecordId(String(repoId));
+
+      await db.query(
+        `CREATE issue CONTENT {
+          github_node_id: 'I_OF_1',
+          github_url: 'u',
+          repo: $repo,
+          number: 1,
+          title: 'Issue',
+          body: 'body',
+          state: 'OPEN',
+          author: NONE,
+          created_at: time::now(),
+          updated_at: time::now(),
+          deleted_at: NONE,
+          content_hash: 'hash_p',
+          embedding: NONE,
+          embedded_content_hash: NONE
+        }`,
+        { repo: repoRef },
+      );
+
+      const { exitCode } = await runCapturingExit(() => run([nwo]));
+      expect(exitCode).toBe(1);
+      expect(embedManyCallCount).toBe(0);
+
+      const [[issue]] = await db.query<[[{ embedding: unknown }]]>(
+        "SELECT embedding FROM issue WHERE github_node_id = 'I_OF_1'",
+      );
+      expect(issue.embedding == null).toBe(true);
+    });
+    testDb = null;
+  });
+});
+
+describe("embed command — per-item failure after first success", () => {
+  it("completes run, embeds first item, logs second as failed, exits non-zero", async () => {
+    await withTestDb(async (db) => {
+      testDb = db;
+      embedManyCallCount = 0;
+      let callIndex = 0;
+      embedManyImpl = async (texts) => {
+        callIndex++;
+        if (callIndex === 1) return texts.map(() => new Array(768).fill(0.5));
+        throw new Error("embedding service error");
+      };
+      embedProbeImpl = async () => new Array(768).fill(0.1);
+
+      const { repoId, nwo } = await seedRepoAndOrg(db, "PF");
+      const repoRef = new StringRecordId(String(repoId));
+
+      // issue → embedMany call #1 (succeeds)
+      await db.query(
+        `CREATE issue CONTENT {
+          github_node_id: 'I_PF_1',
+          github_url: 'u',
+          repo: $repo,
+          number: 1,
+          title: 'Issue',
+          body: 'body',
+          state: 'OPEN',
+          author: NONE,
+          created_at: time::now(),
+          updated_at: time::now(),
+          deleted_at: NONE,
+          content_hash: 'h_issue',
+          embedding: NONE,
+          embedded_content_hash: NONE
+        }`,
+        { repo: repoRef },
+      );
+      // pull_request → embedMany call #2 (throws)
+      await db.query(
+        `CREATE pull_request CONTENT {
+          github_node_id: 'PR_PF_1',
+          github_url: 'u',
+          repo: $repo,
+          number: 1,
+          title: 'PR',
+          body: 'body',
+          state: 'OPEN',
+          author: NONE,
+          closed_at: NONE,
+          merged_at: NONE,
+          created_at: time::now(),
+          updated_at: time::now(),
+          deleted_at: NONE,
+          content_hash: 'h_pr',
+          embedding: NONE,
+          embedded_content_hash: NONE
+        }`,
+        { repo: repoRef },
+      );
+
+      const { exitCode } = await runCapturingExit(() => run([nwo]));
+      expect(exitCode).toBe(1);
+
+      const [[issue]] = await db.query<
+        [[{ embedding: unknown; embedded_content_hash: string }]]
+      >(
+        "SELECT embedding, embedded_content_hash FROM issue WHERE github_node_id = 'I_PF_1'",
+      );
+      expect(issue.embedding).not.toBeNull();
+      expect(issue.embedded_content_hash).toBe("h_issue");
+
+      const [[pr]] = await db.query<[[{ embedding: unknown }]]>(
+        "SELECT embedding FROM pull_request WHERE github_node_id = 'PR_PF_1'",
+      );
+      expect(pr.embedding == null).toBe(true);
+    });
+    testDb = null;
+  });
+});

--- a/src/commands/embed.ts
+++ b/src/commands/embed.ts
@@ -1,0 +1,147 @@
+import { withDb } from "../clients/surreal.ts";
+import { embed, embedMany } from "../clients/ollama.ts";
+import { embedText } from "../ingest/embed_text.ts";
+import { StringRecordId } from "surrealdb";
+import { config } from "../config.ts";
+
+const BATCH_SIZE = 16;
+
+type EmbedCandidate = {
+  id: unknown;
+  github_node_id: string;
+  title?: string | null;
+  body: string | null;
+  content_hash: string;
+};
+
+export default async function run(args: string[]): Promise<void> {
+  const input = args[0];
+  if (!input || !/^[^/]+\/[^/]+$/.test(input)) {
+    console.error("✗ Usage: tool embed <owner/name>");
+    process.exit(1);
+  }
+
+  await withDb(async (db) => {
+    // 1. Load repo
+    const [repoRows] = await db.query<
+      [Array<{ id: unknown; name_with_owner: string; registered_at: unknown }>]
+    >("SELECT id, name_with_owner, registered_at FROM repo WHERE name_with_owner = $nwo", {
+      nwo: input,
+    });
+    const repoRow = repoRows[0];
+    if (!repoRow || repoRow.registered_at == null) {
+      throw new Error("repo not registered — use `tool add` first");
+    }
+    const repoRef = new StringRecordId(String(repoRow.id));
+
+    // 2. Probe Ollama
+    try {
+      await embed("ping");
+    } catch (err) {
+      console.error(`✗ Ollama not reachable at ${config.OLLAMA_URL}: ${err}`);
+      process.exit(1);
+    }
+
+    // 3. Process each kind
+    const kinds = ["issue", "pull_request", "discussion", "comment"] as const;
+    const labels: Record<string, string> = {
+      issue: "Issues",
+      pull_request: "PRs",
+      discussion: "Discussions",
+      comment: "Comments",
+    };
+
+    let totalEmbedded = 0;
+    let totalFailed = 0;
+    let successCount = 0;
+    let consecutiveFailsFromStart = 0;
+
+    for (const kind of kinds) {
+      let candidates: EmbedCandidate[];
+
+      if (kind === "comment") {
+        const [rows] = await db.query<[EmbedCandidate[]]>(
+          `SELECT id, github_node_id, body, content_hash FROM comment
+           WHERE (parent_issue.repo = $repoRef OR parent_pr.repo = $repoRef OR parent_discussion.repo = $repoRef)
+           AND deleted_at IS NONE
+           AND content_hash != NONE
+           AND (author IS NONE OR author.is_bot != true)
+           AND (embedding = NONE OR embedded_content_hash != content_hash)`,
+          { repoRef },
+        );
+        candidates = rows;
+      } else {
+        const [rows] = await db.query<[EmbedCandidate[]]>(
+          `SELECT id, github_node_id, title, body, content_hash FROM ${kind}
+           WHERE repo = $repoRef
+           AND deleted_at IS NONE
+           AND content_hash != NONE
+           AND (author IS NONE OR author.is_bot != true)
+           AND (embedding = NONE OR embedded_content_hash != content_hash)`,
+          { repoRef },
+        );
+        candidates = rows;
+      }
+
+      let embedded = 0;
+      let failed = 0;
+
+      for (let i = 0; i < candidates.length; i += BATCH_SIZE) {
+        const batch = candidates.slice(i, i + BATCH_SIZE);
+        const texts = batch.map((item) => embedText({ title: item.title, body: item.body }));
+
+        let vectors: number[][];
+        try {
+          vectors = await embedMany(texts);
+        } catch (err) {
+          if (successCount === 0) {
+            consecutiveFailsFromStart += batch.length;
+            if (consecutiveFailsFromStart >= 3) {
+              throw err;
+            }
+          }
+          for (const item of batch) {
+            console.error(`✗ Failed to embed ${kind} ${item.github_node_id}: ${err}`);
+            failed++;
+          }
+          continue;
+        }
+
+        for (let j = 0; j < batch.length; j++) {
+          const item = batch[j];
+          const vector = vectors[j];
+          try {
+            await db.query(
+              "UPDATE $id SET embedding = $vector, embedded_content_hash = $hash",
+              {
+                id: new StringRecordId(String(item.id)),
+                vector,
+                hash: item.content_hash,
+              },
+            );
+            successCount++;
+            embedded++;
+          } catch (updateErr) {
+            if (successCount === 0) {
+              consecutiveFailsFromStart++;
+              if (consecutiveFailsFromStart >= 3) {
+                throw updateErr;
+              }
+            }
+            console.error(`✗ Failed to update ${kind} ${item.github_node_id}: ${updateErr}`);
+            failed++;
+          }
+        }
+      }
+
+      console.log(`✓ ${labels[kind]}: ${embedded} embedded, ${failed} failed`);
+      totalEmbedded += embedded;
+      totalFailed += failed;
+    }
+
+    console.log(`✓ Total: ${totalEmbedded} embedded, ${totalFailed} failed`);
+    if (totalFailed > 0) {
+      process.exit(1);
+    }
+  });
+}

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -4,6 +4,7 @@ export default function run(): void {
   console.log("Commands:");
   console.log("  add      Register a GitHub repo for mirroring (tool add owner/name)");
   console.log("  sync     Sync a registered repo (tool sync owner/name)");
+  console.log("  embed    Embed pending content for a synced repo (tool embed owner/name)");
   console.log("  list     List registered repos (tool list [--json])");
   console.log("  remove   Unregister a repo (tool remove owner/name [--purge] [--yes])");
   console.log("  inspect  Inspect a mirrored repo snapshot (tool inspect owner/name [--json])");

--- a/src/ingest/embed_text.test.ts
+++ b/src/ingest/embed_text.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from "bun:test";
+import { embedText } from "./embed_text";
+
+describe("embedText", () => {
+  it("joins title and body with double newline", () => {
+    expect(embedText({ title: "Foo", body: "Bar" })).toBe("Foo\n\nBar");
+  });
+
+  it("returns body only when title is absent", () => {
+    expect(embedText({ body: "comment text" })).toBe("comment text");
+  });
+
+  it("returns empty string when both are null", () => {
+    expect(embedText({ title: null, body: null })).toBe("");
+  });
+
+  it("normalises CRLF in body", () => {
+    expect(embedText({ title: "T", body: "Body with\r\nCRLF" })).toBe("T\n\nBody with\nCRLF");
+  });
+});

--- a/src/ingest/embed_text.ts
+++ b/src/ingest/embed_text.ts
@@ -1,0 +1,5 @@
+export function embedText(node: { title?: string | null; body: string | null }): string {
+  const title = node.title ?? "";
+  const body = (node.body ?? "").replace(/\r\n/g, "\n");
+  return title ? `${title}\n\n${body}` : body;
+}


### PR DESCRIPTION
## Summary

`tool embed <owner/name>` — second-pass command that walks embeddable nodes for a synced repo and populates their `embedding` via Ollama. Closes the milestone.

The command:
1. Loads the repo (errors loudly if not registered).
2. Probes Ollama once with a `ping` embed; infrastructure failure exits non-zero immediately.
3. For each kind (issue → pull_request → discussion → comment), queries candidates whose `embedding IS NONE OR embedded_content_hash != content_hash` and whose author is not a bot (author=NULL embeds — only `is_bot = true` is the skip condition).
4. Embeds in batches of 16 via `embedMany`. Per-item failures after the first success are logged and skipped (per the `Item-level failures don't fail the batch` principle); a run with ≥3 consecutive failures and zero successes throws (infrastructure heuristic).
5. Updates `embedding` and `embedded_content_hash` atomically per item; re-running on unchanged content is a no-op.

## Schema migration

Additive (`IF NOT EXISTS` guards):

```surql
DEFINE FIELD IF NOT EXISTS embedded_content_hash ON TABLE issue         TYPE option<string>;
DEFINE FIELD IF NOT EXISTS embedded_content_hash ON TABLE pull_request  TYPE option<string>;
DEFINE FIELD IF NOT EXISTS embedded_content_hash ON TABLE discussion    TYPE option<string>;
DEFINE FIELD IF NOT EXISTS embedded_content_hash ON TABLE comment       TYPE option<string>;
```

Implements the "Skip re-embedding on unchanged content" principle — items with `embedded_content_hash == content_hash` are not re-embedded on subsequent runs.

## Test plan

- [x] `bun run typecheck` — clean.
- [x] `bun test` — 94/94 pass across 16 files (7 new embed.test.ts cases + 1 embed_text.test.ts).
- [x] Happy path: issues with `embedding IS NONE` get embedded; their `embedded_content_hash` matches their `content_hash`.
- [x] Bot skip: bot-authored items stay unembedded.
- [x] Up-to-date skip: items with `embedded_content_hash == content_hash` aren't re-embedded.
- [x] Re-embed on content change: bumping `content_hash` triggers re-embedding on the next run.
- [x] Author=NULL items embed (deleted upstream user, etc.).
- [x] Ollama probe failure: exits non-zero with a clear message; no embeddings written.
- [x] Per-item failure (skip-and-continue): after first success, individual failures are logged and the run continues; final exit non-zero with summary.
- [ ] **Manual end-to-end** against `lfnovo/esperanto` after `tool sync` populates data — for the milestone PR description.
- [ ] `bun run smoke:*` (manual; unaffected).

## Architectural notes

- **Single `withDb` scope** for the whole run.
- **Sequential batches** within a kind; sequential across kinds. No concurrency.
- **No `--json`** — embed is an action command per the read-vs-action distinction.
- **No bulk mode** — requires explicit `owner/name`.
- **`embed` is the second pass after `sync`** — the orchestrator (`tool sync`) does NOT call it. Embedding can lag content ingest by hours.
- **Comment scoping** via the three nullable parent fields (`parent_issue` / `parent_pr` / `parent_discussion`) — matches the current schema; will adapt if the schema later refactors to a union.

## Out of scope

- Bulk embed across all registered repos.
- Adaptive batch sizing.
- Concurrent embedding via multiple Ollama instances.
- Chunking long bodies (per-item granularity is the MVP).
- Embedder fallback when Ollama is offline (open VISION question).
- Re-embedding on model change (deliberate migration with its own script).
- Updating `tool inspect` (#12) to use `embedded_content_hash` for staleness — small follow-up after this PR.

Closes #11


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `tool embed <owner/name>` to batch-embed repo content via Ollama, skipping bots and unchanged items, with skip-and-continue error handling. Keeps embeddings fresh as a second pass after sync. Closes #11.

- **New Features**
  - `tool embed <owner/name>` processes issues, PRs, discussions, and comments.
  - Probes Ollama once; embeds in batches of 16; logs item failures; exits non-zero if any fail; aborts early on repeated infra errors.
  - Skips bot-authored items; `author = NULL` still embeds; only missing or stale embeddings are processed.
  - Updates embeddings atomically; re-runs are no-ops on unchanged content. Added `embedText` helper and updated `help`.

- **Migration**
  - Add nullable `embedded_content_hash` to `issue`, `pull_request`, `discussion`, and `comment` (additive, `IF NOT EXISTS`).
  - No manual steps. Apply schema and run `tool embed` after `tool sync`.

<sup>Written for commit ac25b17d52caa7dde4dc71803a6f3626664b36c6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

