### PR TITLE
fix(schema): drop user_login_uniq and org_login_uniq indexes

### DIFF
--- a/schemas.surrealql
+++ b/schemas.surrealql
@@ -17,7 +17,9 @@ DEFINE FIELD IF NOT EXISTS updated_at     ON TABLE org TYPE datetime;
 DEFINE FIELD IF NOT EXISTS deleted_at     ON TABLE org TYPE option<datetime>;
 
 DEFINE INDEX IF NOT EXISTS org_node_id_uniq ON TABLE org FIELDS github_node_id UNIQUE;
-DEFINE INDEX IF NOT EXISTS org_login_uniq   ON TABLE org FIELDS login UNIQUE;
+-- login is NOT unique: GitHub allows account renames and reuse of old logins
+-- by new accounts. We dedupe by github_node_id (the real PK) only.
+REMOVE INDEX IF EXISTS org_login_uniq ON TABLE org;
 
 -- =====================================================================
 -- repo — a mirrored GitHub repository
@@ -56,7 +58,10 @@ DEFINE FIELD IF NOT EXISTS updated_at     ON TABLE user TYPE datetime;
 DEFINE FIELD IF NOT EXISTS deleted_at     ON TABLE user TYPE option<datetime>;
 
 DEFINE INDEX IF NOT EXISTS user_node_id_uniq ON TABLE user FIELDS github_node_id UNIQUE;
-DEFINE INDEX IF NOT EXISTS user_login_uniq   ON TABLE user FIELDS login UNIQUE;
+-- login is NOT unique: GitHub allows account renames and reuse of old logins
+-- by new accounts. We dedupe by github_node_id (the real PK) only.
+-- Surfaced during the first end-to-end sync of `lfnovo/esperanto`.
+REMOVE INDEX IF EXISTS user_login_uniq ON TABLE user;
 
 -- =====================================================================
 -- label — a label on issues/PRs/discussions (scoped to a repo)


### PR DESCRIPTION
Surfaced during the first end-to-end sync of `lfnovo/esperanto`:

```
error: Database index `user_login_uniq` already contains 'claude',
with record `user:1nxdpns6vze56m7x8ypu`
```

The unique constraint on `user.login` fails when GitHub returns the
same login with a different `github_node_id` — renamed accounts,
reclaimed handles, ghost users, mannequins. `upsertUser` correctly
dedupes by `github_node_id` (the real PK); `login` is a friendly
identifier only.

Same reasoning applies to `org.login` (renames are less common at the
org level, but the same class of bug exists).

Schema migration is non-destructive: `REMOVE INDEX IF EXISTS` runs on
existing DBs as part of `bun run schema:apply`. Re-running is safe.

## Test plan
- [x] `bun run schema:apply` clean.
- [x] `bun run typecheck && bun test` — 94/94 pass.
- [ ] `bun run src/index.ts sync lfnovo/esperanto` no longer crashes on duplicate login (re-running e2e after merge).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Drop the unique indexes `user_login_uniq` and `org_login_uniq` to prevent sync crashes when GitHub reuses or renames logins. Deduping now relies only on `github_node_id`.

- **Bug Fixes**
  - Non-destructive migration using `REMOVE INDEX IF EXISTS`, applied via `bun run schema:apply` and safe to rerun.

<sup>Written for commit 089db47c327cceaa1bdc630305c33e1874c9f7e6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

