### PR TITLE
fix(embed): truncate long inputs to fit nomic-embed-text 8K context

### DIFF
--- a/src/ingest/embed_text.test.ts
+++ b/src/ingest/embed_text.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "bun:test";
-import { embedText } from "./embed_text";
+import { embedText, EMBED_TEXT_MAX_CHARS } from "./embed_text";
 
 describe("embedText", () => {
   it("joins title and body with double newline", () => {
@@ -16,5 +16,16 @@ describe("embedText", () => {
 
   it("normalises CRLF in body", () => {
     expect(embedText({ title: "T", body: "Body with\r\nCRLF" })).toBe("T\n\nBody with\nCRLF");
+  });
+
+  it("truncates inputs longer than EMBED_TEXT_MAX_CHARS", () => {
+    const longBody = "x".repeat(EMBED_TEXT_MAX_CHARS + 100);
+    const out = embedText({ title: null, body: longBody });
+    expect(out.length).toBe(EMBED_TEXT_MAX_CHARS);
+  });
+
+  it("does not truncate inputs at or below the cap", () => {
+    const exact = "x".repeat(EMBED_TEXT_MAX_CHARS);
+    expect(embedText({ title: null, body: exact }).length).toBe(EMBED_TEXT_MAX_CHARS);
   });
 });

--- a/src/ingest/embed_text.ts
+++ b/src/ingest/embed_text.ts
@@ -1,5 +1,13 @@
+// Conservative cap to stay inside `nomic-embed-text`'s 8192-token context.
+// At ~4 chars/token average for prose, 24000 chars ≈ 6000 tokens with headroom
+// for code-heavy or symbol-heavy content. Items longer than this lose their
+// tail in the embedding; the full body is still preserved on the row for
+// retrieval-time access.
+export const EMBED_TEXT_MAX_CHARS = 24000;
+
 export function embedText(node: { title?: string | null; body: string | null }): string {
   const title = node.title ?? "";
   const body = (node.body ?? "").replace(/\r\n/g, "\n");
-  return title ? `${title}\n\n${body}` : body;
+  const full = title ? `${title}\n\n${body}` : body;
+  return full.length > EMBED_TEXT_MAX_CHARS ? full.slice(0, EMBED_TEXT_MAX_CHARS) : full;
 }


### PR DESCRIPTION
Surfaced during the first end-to-end embed of `lfnovo/esperanto`:

```
error: HTTP 400: {"error":"the input length exceeds the context length"}
```

A single long PR body inside a batch of 16 made Ollama reject the whole batch.
Combined with the first-success heuristic (`successCount === 0` and ≥3
fails ⇒ infrastructure crash), the run aborted before any item was
embedded.

`nomic-embed-text` supports 8192 tokens. 24000 chars is a conservative
proxy (~6K tokens with headroom for code/symbol-heavy content). Items
longer than the cap lose their tail in the embedding only — the full
body stays on the row for retrieval-time access.

A follow-up worth filing: chunk long bodies into multiple embedding
rows (open in VISION as a post-MVP concern). For First Full Sync,
truncation is the pragmatic call.

## Test plan
- [x] `bun run typecheck && bun test` — 96/96 pass (2 new truncation tests).
- [ ] `bun run src/index.ts embed lfnovo/esperanto` to completion (re-running e2e after merge).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Truncate embed inputs to 24,000 characters to fit `nomic-embed-text` 8K context and prevent batch failures on long PR bodies. Only the embedding is truncated; the stored body remains intact.

- **Bug Fixes**
  - Add `EMBED_TEXT_MAX_CHARS = 24000` and slice in `embedText`.
  - Prevent Ollama 400 "input length exceeds context length" that rejected batches and triggered early aborts.
  - Add truncation tests, including boundary checks.

<sup>Written for commit 43a83a541dde92f2a304b5e73a74932f69324856. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

