### PR TITLE
fix(embed): tighten truncation cap to 8000 chars

### DIFF
--- a/src/ingest/embed_text.ts
+++ b/src/ingest/embed_text.ts
@@ -1,9 +1,14 @@
-// Conservative cap to stay inside `nomic-embed-text`'s 8192-token context.
-// At ~4 chars/token average for prose, 24000 chars ≈ 6000 tokens with headroom
-// for code-heavy or symbol-heavy content. Items longer than this lose their
-// tail in the embedding; the full body is still preserved on the row for
-// retrieval-time access.
-export const EMBED_TEXT_MAX_CHARS = 24000;
+// Hard cap to stay inside `nomic-embed-text`'s 8192-token context window.
+// 8000 chars is the safe-regardless-of-tokenization figure: even at
+// 1 char per token (worst case for dense code, non-Latin scripts, or
+// heavily-tokenized symbols), this stays under the 8192-token context.
+// Items longer than this lose their tail in the embedding only — the
+// full body remains on the row for retrieval-time access.
+//
+// (The earlier 24000-char value, derived from a 4-chars-per-token
+// English-prose assumption, failed end-to-end on lfnovo/esperanto when
+// a PR body's tokenization came out far denser than the heuristic.)
+export const EMBED_TEXT_MAX_CHARS = 8000;
 
 export function embedText(node: { title?: string | null; body: string | null }): string {
   const title = node.title ?? "";


### PR DESCRIPTION
Follow-up to #34: 24000 chars (derived from a 4-chars-per-token assumption for English prose) still failed end-to-end against `lfnovo/esperanto`. At least one PR body's tokenization comes out denser — closer to 1-2 chars/token, likely heavy code or compacted content.

8000 chars is the safe-regardless-of-tokenization figure: even at the worst case of 1 char ≈ 1 token, this stays under the 8192-token context. Items longer than this lose their tail in the embedding only; the full body remains on the row for retrieval-time access.

Future, if retrieval quality on long items becomes a real concern: chunk per item per the open VISION question.

## Test plan
- [x] `bun run typecheck && bun test` — 96/96 pass.
- [ ] `bun run src/index.ts embed lfnovo/esperanto` to completion.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduced embed truncation cap from 24000 to 8000 characters to stay within `nomic-embed-text`’s 8192-token context. Prevents failures on dense content (e.g., code or non‑Latin scripts); only the embedding is truncated, the full body remains for retrieval.

<sup>Written for commit 83db94320ebb644123e9d06fac7817ace51c6164. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

