### PR TITLE
fix(embed): per-item fallback when batch fails

### DIFF
--- a/src/commands/embed.ts
+++ b/src/commands/embed.ts
@@ -90,26 +90,40 @@ export default async function run(args: string[]): Promise<void> {
         const batch = candidates.slice(i, i + BATCH_SIZE);
         const texts = batch.map((item) => embedText({ title: item.title, body: item.body }));
 
-        let vectors: number[][];
+        // Batch path: try the whole batch in one Ollama call.
+        // Per-item fallback: if the batch fails (typically because ONE item
+        // exceeds context length), retry items individually so the others
+        // still embed. Items that fail at size 1 are truly bad and skipped.
+        let vectors: (number[] | null)[] = [];
         try {
           vectors = await embedMany(texts);
-        } catch (err) {
-          if (successCount === 0) {
-            consecutiveFailsFromStart += batch.length;
-            if (consecutiveFailsFromStart >= 3) {
-              throw err;
+        } catch {
+          // Fall back to per-item embedding to isolate the offender.
+          for (let j = 0; j < texts.length; j++) {
+            try {
+              const single = await embedMany([texts[j]]);
+              vectors.push(single[0]);
+            } catch (perItemErr) {
+              if (successCount === 0) {
+                consecutiveFailsFromStart++;
+                if (consecutiveFailsFromStart >= 3) {
+                  throw perItemErr;
+                }
+              }
+              console.error(
+                `✗ Failed to embed ${kind} ${batch[j].github_node_id}: ${perItemErr}`,
+              );
+              failed++;
+              vectors.push(null);
             }
           }
-          for (const item of batch) {
-            console.error(`✗ Failed to embed ${kind} ${item.github_node_id}: ${err}`);
-            failed++;
-          }
-          continue;
         }
 
+        // Persist vectors for items that produced one.
         for (let j = 0; j < batch.length; j++) {
-          const item = batch[j];
           const vector = vectors[j];
+          if (vector === null) continue;
+          const item = batch[j];
           try {
             await db.query(
               "UPDATE $id SET embedding = $vector, embedded_content_hash = $hash",


### PR DESCRIPTION
Surfaced during the third e2e attempt: 99 PRs embedded, 16 PRs reported failed. Inspecting the failed items showed most were short, well-formed bodies. The real cause: ONE item in a batch of 16 exceeded the context length, and Ollama rejected the entire batch with HTTP 400. The previous code counted all 16 as failed.

Now: when `embedMany` throws on a batch, we retry items individually. The 15 healthy items embed; only the genuinely-too-long item fails. Failure-counting is per-item, not per-batch.

Combined with the truncation cap from #36, real failures should now be rare — limited to items whose dense tokenization makes even 6000 chars exceed 8192 tokens.

## Test plan
- [x] `bun run typecheck && bun test` — 96/96 pass.
- [ ] `bun run src/index.ts embed lfnovo/esperanto` to completion (re-running e2e after merge).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add per-item fallback when a batch embedding fails so one oversize item no longer causes the entire batch to fail. Successful items now embed; only the offending item is marked failed.

- **Bug Fixes**
  - On `embedMany` batch error, retry each item individually and mark only true failures.
  - Persist embeddings for successful items; skip nulls instead of failing the whole batch.
  - With truncation from #36, failures should be rare and limited to extreme tokenization cases.

<sup>Written for commit 674b6c7c7b37f5870f3087f4049f57ed5b190401. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

