### PR TITLE
feat: tool search — vector similarity query CLI

### DIFF
--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -8,6 +8,7 @@ export default function run(): void {
   console.log("  list     List registered repos (tool list [--json])");
   console.log("  remove   Unregister a repo (tool remove owner/name [--purge] [--yes])");
   console.log("  inspect  Inspect a mirrored repo snapshot (tool inspect owner/name [--json])");
+  console.log("  search   Semantic search across mirrored repos (tool search \"query\" [--repo owner/name] [--kind ...] [--limit N] [--json])");
   console.log("  help     Show this help message");
   process.exit(0);
 }

--- a/src/commands/search.test.ts
+++ b/src/commands/search.test.ts
@@ -1,0 +1,467 @@
+import { describe, it, expect, mock } from "bun:test";
+import type { Surreal } from "surrealdb";
+import { StringRecordId } from "surrealdb";
+import { withTestDb } from "../test_utils/with_test_db.ts";
+
+let testDb: Surreal | null = null;
+let embedImpl: () => Promise<number[]> = async () => VEC_QUERY.slice();
+
+mock.module("../clients/ollama.ts", () => ({
+  embed: (_text: string) => embedImpl(),
+  embedMany: (texts: string[]) => Promise.all(texts.map(() => embedImpl())),
+}));
+
+mock.module("../clients/surreal.ts", () => ({
+  withDb: (fn: (db: Surreal) => Promise<unknown>) => fn(testDb!),
+}));
+
+const { default: run } = await import("./search.ts");
+
+const VEC_QUERY = new Array(768).fill(0).map((_, i) => (i === 0 ? 1 : 0));
+const VEC_HIGH = new Array(768).fill(0).map((_, i) => (i === 0 ? 1 : 0));
+const VEC_MED = new Array(768).fill(0).map((_, i) => (i === 0 ? 0.9 : i === 1 ? 0.1 : 0));
+const VEC_LOW = new Array(768).fill(0).map((_, i) => (i === 1 ? 1 : 0));
+
+type RunResult = { exitCode: number | undefined; stdout: string; stderr: string };
+
+async function runCapturing(fn: () => Promise<void>): Promise<RunResult> {
+  const origExit = process.exit;
+  const origLog = console.log;
+  const origError = console.error;
+  let exitCode: number | undefined;
+  const stdoutLines: string[] = [];
+  const stderrLines: string[] = [];
+
+  (process as any).exit = (code?: number) => {
+    exitCode = code;
+    throw new Error(`__exit__${code}`);
+  };
+  console.log = (...args: any[]) => stdoutLines.push(args.map(String).join(" "));
+  console.error = (...args: any[]) => stderrLines.push(args.map(String).join(" "));
+
+  try {
+    await fn();
+  } catch (e) {
+    if (!(e instanceof Error && e.message.startsWith("__exit__"))) {
+      (process as any).exit = origExit;
+      console.log = origLog;
+      console.error = origError;
+      throw e;
+    }
+  } finally {
+    (process as any).exit = origExit;
+    console.log = origLog;
+    console.error = origError;
+  }
+
+  return { exitCode, stdout: stdoutLines.join("\n"), stderr: stderrLines.join("\n") };
+}
+
+async function seedRepo(
+  db: Surreal,
+  suffix: string,
+): Promise<{ repoId: unknown; repoRef: StringRecordId; nwo: string }> {
+  const [orgRows] = await db.query<[Array<{ id: unknown }>]>(
+    `CREATE org CONTENT {
+      github_node_id: $gid,
+      github_url: 'https://github.com/testorg',
+      login: $login,
+      name: NONE,
+      kind: 'Organization',
+      created_at: time::now(),
+      updated_at: time::now(),
+      deleted_at: NONE
+    }`,
+    { gid: `ORG_${suffix}`, login: `testorg_${suffix}` },
+  );
+  const orgId = orgRows[0].id;
+
+  const nwo = `testorg_${suffix}/test-repo`;
+  const [repoRows] = await db.query<[Array<{ id: unknown }>]>(
+    `CREATE repo CONTENT {
+      github_node_id: $gid,
+      github_url: $url,
+      name: 'test-repo',
+      name_with_owner: $nwo,
+      description: NONE,
+      is_private: false,
+      owner: $owner,
+      created_at: time::now(),
+      updated_at: time::now(),
+      registered_at: time::now()
+    }`,
+    { gid: `REPO_${suffix}`, nwo, url: `https://github.com/${nwo}`, owner: orgId },
+  );
+  const repoId = repoRows[0].id;
+  return { repoId, repoRef: new StringRecordId(String(repoId)), nwo };
+}
+
+async function seedIssue(
+  db: Surreal,
+  repoRef: StringRecordId,
+  suffix: string,
+  opts: { number: number; title: string; embedding: number[] | null },
+) {
+  const embeddingExpr = opts.embedding !== null ? "$embedding" : "NONE";
+  await db.query(
+    `CREATE issue CONTENT {
+      github_node_id: $gid,
+      github_url: $url,
+      repo: $repo,
+      number: $number,
+      title: $title,
+      body: 'body',
+      state: 'OPEN',
+      author: NONE,
+      created_at: time::now(),
+      updated_at: time::now(),
+      deleted_at: NONE,
+      content_hash: $hash,
+      embedding: ${embeddingExpr},
+      embedded_content_hash: NONE
+    }`,
+    {
+      gid: `I_${suffix}`,
+      url: `https://github.com/owner/repo/issues/${opts.number}`,
+      repo: repoRef,
+      number: opts.number,
+      title: opts.title,
+      hash: `hash_${suffix}`,
+      ...(opts.embedding !== null ? { embedding: opts.embedding } : {}),
+    },
+  );
+}
+
+describe("search command — happy path, single repo", () => {
+  it("returns results sorted by cosine similarity", async () => {
+    await withTestDb(async (db) => {
+      testDb = db;
+      embedImpl = async () => VEC_QUERY.slice();
+
+      const { repoRef } = await seedRepo(db, "HP");
+      await seedIssue(db, repoRef, "HP_3", { number: 3, title: "Issue High", embedding: VEC_HIGH.slice() });
+      await seedIssue(db, repoRef, "HP_7", { number: 7, title: "Issue Med", embedding: VEC_MED.slice() });
+      await seedIssue(db, repoRef, "HP_1", { number: 1, title: "Issue Low", embedding: VEC_LOW.slice() });
+
+      const result = await runCapturing(() => run(["test query", "--json"]));
+      expect(result.exitCode).toBeUndefined();
+      const parsed = JSON.parse(result.stdout) as Array<{ number: number }>;
+      expect(parsed[0].number).toBe(3);
+      expect(parsed[1].number).toBe(7);
+    });
+    testDb = null;
+  });
+});
+
+describe("search command — JSON output", () => {
+  it("emits parseable JSON array with required keys", async () => {
+    await withTestDb(async (db) => {
+      testDb = db;
+      embedImpl = async () => VEC_QUERY.slice();
+
+      const { repoRef, nwo } = await seedRepo(db, "JS");
+      await seedIssue(db, repoRef, "JS_1", { number: 1, title: "JS Issue", embedding: VEC_HIGH.slice() });
+      await seedIssue(db, repoRef, "JS_2", { number: 2, title: "JS Issue 2", embedding: VEC_MED.slice() });
+
+      const result = await runCapturing(() => run(["test query", "--json"]));
+      expect(result.exitCode).toBeUndefined();
+      const parsed = JSON.parse(result.stdout) as Array<Record<string, unknown>>;
+      expect(Array.isArray(parsed)).toBe(true);
+      for (const obj of parsed) {
+        expect(obj).toHaveProperty("kind");
+        expect(obj).toHaveProperty("repo");
+        expect(obj).toHaveProperty("number");
+        expect(obj).toHaveProperty("title");
+        expect(obj).toHaveProperty("url");
+        expect(obj).toHaveProperty("score");
+        expect(obj.repo).toBe(nwo);
+      }
+    });
+    testDb = null;
+  });
+});
+
+describe("search command — --repo scope", () => {
+  it("scopes results to the specified repo", async () => {
+    await withTestDb(async (db) => {
+      testDb = db;
+      embedImpl = async () => VEC_QUERY.slice();
+
+      const { repoRef: refA, nwo: nwoA } = await seedRepo(db, "SCA");
+      const { repoRef: refB } = await seedRepo(db, "SCB");
+
+      await seedIssue(db, refA, "SCA_1", { number: 1, title: "Repo A Issue 1", embedding: VEC_HIGH.slice() });
+      await seedIssue(db, refA, "SCA_2", { number: 2, title: "Repo A Issue 2", embedding: VEC_MED.slice() });
+      await seedIssue(db, refB, "SCB_1", { number: 1, title: "Repo B Issue 1", embedding: VEC_HIGH.slice() });
+
+      const result = await runCapturing(() => run(["test query", "--repo", nwoA, "--json"]));
+      expect(result.exitCode).toBeUndefined();
+      const parsed = JSON.parse(result.stdout) as Array<{ repo: string }>;
+      expect(parsed.length).toBeGreaterThan(0);
+      for (const obj of parsed) {
+        expect(obj.repo).toBe(nwoA);
+      }
+    });
+    testDb = null;
+  });
+});
+
+describe("search command — --kind issue", () => {
+  it("excludes pull_request results when --kind issue", async () => {
+    await withTestDb(async (db) => {
+      testDb = db;
+      embedImpl = async () => VEC_QUERY.slice();
+
+      const { repoRef } = await seedRepo(db, "KI");
+      await seedIssue(db, repoRef, "KI_1", { number: 1, title: "KI Issue", embedding: VEC_HIGH.slice() });
+
+      await db.query(
+        `CREATE pull_request CONTENT {
+          github_node_id: 'PR_KI_1',
+          github_url: 'https://github.com/owner/repo/pull/1',
+          repo: $repo,
+          number: 1,
+          title: 'KI Pull Request',
+          body: 'body',
+          state: 'OPEN',
+          author: NONE,
+          closed_at: NONE,
+          merged_at: NONE,
+          created_at: time::now(),
+          updated_at: time::now(),
+          deleted_at: NONE,
+          content_hash: 'hash_pr_ki',
+          embedding: $embedding,
+          embedded_content_hash: NONE
+        }`,
+        { repo: repoRef, embedding: VEC_MED.slice() },
+      );
+
+      const result = await runCapturing(() => run(["test query", "--kind", "issue", "--json"]));
+      expect(result.exitCode).toBeUndefined();
+      const parsed = JSON.parse(result.stdout) as Array<{ kind: string }>;
+      expect(parsed.every((r) => r.kind === "issue")).toBe(true);
+      expect(parsed.some((r) => r.kind === "pull_request")).toBe(false);
+    });
+    testDb = null;
+  });
+});
+
+describe("search command — --limit", () => {
+  it("returns exactly --limit results", async () => {
+    await withTestDb(async (db) => {
+      testDb = db;
+      embedImpl = async () => VEC_QUERY.slice();
+
+      const { repoRef } = await seedRepo(db, "LM");
+      for (let i = 1; i <= 5; i++) {
+        await seedIssue(db, repoRef, `LM_${i}`, {
+          number: i,
+          title: `Limit Issue ${i}`,
+          embedding: VEC_HIGH.slice(),
+        });
+      }
+
+      const result = await runCapturing(() => run(["test query", "--limit", "1", "--json"]));
+      expect(result.exitCode).toBeUndefined();
+      const parsed = JSON.parse(result.stdout) as unknown[];
+      expect(parsed).toHaveLength(1);
+    });
+    testDb = null;
+  });
+});
+
+describe("search command — empty matches", () => {
+  it("prints friendly hint in human mode when no embeddings", async () => {
+    await withTestDb(async (db) => {
+      testDb = db;
+      embedImpl = async () => VEC_QUERY.slice();
+
+      await seedRepo(db, "EM");
+
+      const result = await runCapturing(() => run(["test query"]));
+      expect(result.exitCode).toBeUndefined();
+      expect(result.stdout).toContain("no matches");
+    });
+    testDb = null;
+  });
+
+  it("returns [] in JSON mode when no embeddings", async () => {
+    await withTestDb(async (db) => {
+      testDb = db;
+      embedImpl = async () => VEC_QUERY.slice();
+
+      await seedRepo(db, "EMJ");
+
+      const result = await runCapturing(() => run(["test query", "--json"]));
+      expect(result.exitCode).toBeUndefined();
+      const parsed = JSON.parse(result.stdout);
+      expect(parsed).toEqual([]);
+    });
+    testDb = null;
+  });
+});
+
+describe("search command — unregistered repo", () => {
+  it("exits 1 with error when --repo is not registered", async () => {
+    await withTestDb(async (db) => {
+      testDb = db;
+      embedImpl = async () => VEC_QUERY.slice();
+
+      const result = await runCapturing(() => run(["test query", "--repo", "nobody/nope"]));
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain("not registered");
+    });
+    testDb = null;
+  });
+});
+
+describe("search command — Ollama unreachable", () => {
+  it("exits non-zero with ✗ Ollama message when embed throws", async () => {
+    await withTestDb(async (db) => {
+      testDb = db;
+      embedImpl = async () => {
+        throw new Error("connection refused");
+      };
+
+      await seedRepo(db, "OE");
+      await seedIssue(db, (await seedRepo(db, "OE2")).repoRef, "OE2_1", {
+        number: 1,
+        title: "Issue",
+        embedding: VEC_HIGH.slice(),
+      });
+
+      // Seed a proper repo so we get past the repo check and hit embed
+      const { repoRef, nwo } = await seedRepo(db, "OE3");
+      await seedIssue(db, repoRef, "OE3_1", { number: 1, title: "Issue", embedding: VEC_HIGH.slice() });
+
+      const result = await runCapturing(() => run(["test query"]));
+      expect(result.exitCode).not.toBeUndefined();
+      expect(result.exitCode).not.toBe(0);
+      expect(result.stderr).toContain("✗");
+      expect(result.stderr).toContain("Ollama");
+    });
+    testDb = null;
+  });
+});
+
+describe("search command — bot items absent", () => {
+  it("does not return bot-authored issues with no embedding", async () => {
+    await withTestDb(async (db) => {
+      testDb = db;
+      embedImpl = async () => VEC_QUERY.slice();
+
+      const { repoRef } = await seedRepo(db, "BA");
+
+      const [userRows] = await db.query<[Array<{ id: unknown }>]>(
+        `CREATE user CONTENT {
+          github_node_id: 'BOT_BA_1',
+          github_url: 'https://github.com/bot',
+          login: 'bot-user',
+          name: NONE,
+          is_bot: true,
+          created_at: time::now(),
+          updated_at: time::now(),
+          deleted_at: NONE
+        }`,
+      );
+      const botRef = new StringRecordId(String(userRows[0].id));
+
+      await db.query(
+        `CREATE issue CONTENT {
+          github_node_id: 'I_BA_BOT',
+          github_url: 'https://github.com/owner/repo/issues/2',
+          repo: $repo,
+          number: 2,
+          title: 'Bot Issue',
+          body: 'body',
+          state: 'OPEN',
+          author: $author,
+          created_at: time::now(),
+          updated_at: time::now(),
+          deleted_at: NONE,
+          content_hash: 'hash_bot',
+          embedding: NONE,
+          embedded_content_hash: NONE
+        }`,
+        { repo: repoRef, author: botRef },
+      );
+
+      await seedIssue(db, repoRef, "BA_1", {
+        number: 1,
+        title: "Human Issue",
+        embedding: VEC_HIGH.slice(),
+      });
+
+      const result = await runCapturing(() => run(["test query", "--json"]));
+      expect(result.exitCode).toBeUndefined();
+      const parsed = JSON.parse(result.stdout) as Array<{ number: number; title: string }>;
+      expect(parsed.some((r) => r.title === "Bot Issue")).toBe(false);
+      expect(parsed.some((r) => r.title === "Human Issue")).toBe(true);
+    });
+    testDb = null;
+  });
+});
+
+describe("search command — comment in results", () => {
+  it("returns comment with correct kind, subkind, title, and url", async () => {
+    await withTestDb(async (db) => {
+      testDb = db;
+      embedImpl = async () => VEC_QUERY.slice();
+
+      const { repoRef } = await seedRepo(db, "CM");
+
+      const [issueRows] = await db.query<[Array<{ id: unknown }>]>(
+        `CREATE issue CONTENT {
+          github_node_id: 'I_CM_1',
+          github_url: 'https://github.com/owner/repo/issues/42',
+          repo: $repo,
+          number: 42,
+          title: 'Parent Issue Title',
+          body: 'body',
+          state: 'OPEN',
+          author: NONE,
+          created_at: time::now(),
+          updated_at: time::now(),
+          deleted_at: NONE,
+          content_hash: 'hash_cm_i',
+          embedding: NONE,
+          embedded_content_hash: NONE
+        }`,
+        { repo: repoRef },
+      );
+      const issueRef = new StringRecordId(String(issueRows[0].id));
+
+      const commentUrl = "https://github.com/owner/repo/issues/42#issuecomment-999";
+      await db.query(
+        `CREATE comment CONTENT {
+          github_node_id: 'C_CM_1',
+          github_url: $url,
+          parent_issue: $parentIssue,
+          parent_pr: NONE,
+          parent_discussion: NONE,
+          parent_comment: NONE,
+          author: NONE,
+          body: 'A test comment body',
+          created_at: time::now(),
+          updated_at: time::now(),
+          deleted_at: NONE,
+          content_hash: 'hash_cm_c',
+          embedding: $embedding,
+          embedded_content_hash: 'hash_cm_c'
+        }`,
+        { url: commentUrl, parentIssue: issueRef, embedding: VEC_MED.slice() },
+      );
+
+      const result = await runCapturing(() => run(["test query", "--json"]));
+      expect(result.exitCode).toBeUndefined();
+      const parsed = JSON.parse(result.stdout) as Array<Record<string, unknown>>;
+      const commentResult = parsed.find((r) => r.kind === "comment");
+      expect(commentResult).toBeDefined();
+      expect(commentResult!.subkind).toBe("issue");
+      expect(String(commentResult!.title)).toContain("Parent Issue Title");
+      expect(commentResult!.url).toBe(commentUrl);
+    });
+    testDb = null;
+  });
+});

--- a/src/commands/search.ts
+++ b/src/commands/search.ts
@@ -226,7 +226,7 @@ export default async function run(args: string[]): Promise<void> {
             subkind: parentKind,
             repo: nwo,
             number: parent.number,
-            title: `(comment on) ${parent.title}`,
+            title: parent.title,
             url: comment.github_url,
             score: comment.score,
           });
@@ -277,7 +277,8 @@ export default async function run(args: string[]): Promise<void> {
       } else {
         kindLabel = r.kind;
       }
-      console.log(`${i + 1}. [${kindLabel}] ${r.title} (${r.repo}) — score: ${r.score.toFixed(4)}`);
+      const titlePrefix = r.kind === "comment" ? "(comment on) " : "";
+      console.log(`${i + 1}. [${kindLabel}] ${titlePrefix}${r.title} (${r.repo}) — score: ${r.score.toFixed(4)}`);
       console.log(`   ${r.url}`);
       if (i < results.length - 1) console.log("");
     }

--- a/src/commands/search.ts
+++ b/src/commands/search.ts
@@ -1,0 +1,285 @@
+import { withDb } from "../clients/surreal.ts";
+import { embed } from "../clients/ollama.ts";
+import { StringRecordId } from "surrealdb";
+
+type EntityKind = "issue" | "pull_request" | "discussion";
+type SearchKind = EntityKind | "comment";
+
+type EntityResult = {
+  kind: EntityKind;
+  repo: string;
+  number: number;
+  title: string;
+  url: string;
+  score: number;
+};
+
+type CommentResult = {
+  kind: "comment";
+  subkind: EntityKind;
+  repo: string;
+  number: number;
+  title: string;
+  url: string;
+  score: number;
+};
+
+type SearchResult = EntityResult | CommentResult;
+
+export default async function run(args: string[]): Promise<void> {
+  const positional: string[] = [];
+  let repoArg: string | undefined;
+  let jsonFlag = false;
+  let kindArg = "all";
+  let limitStr: string | undefined;
+
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i];
+    if (a === "--repo") {
+      repoArg = args[++i];
+    } else if (a === "--json") {
+      jsonFlag = true;
+    } else if (a === "--kind") {
+      kindArg = args[++i];
+    } else if (a === "--limit") {
+      limitStr = args[++i];
+    } else if (!a.startsWith("--")) {
+      positional.push(a);
+    }
+  }
+
+  const query = positional[0];
+  if (!query || query.trim() === "") {
+    console.error(
+      "✗ Usage: tool search <query> [--repo owner/name] [--kind issue|pull_request|discussion|comment|all] [--limit N] [--json]",
+    );
+    process.exit(1);
+  }
+
+  const validKinds = ["issue", "pull_request", "discussion", "comment", "all"];
+  if (!validKinds.includes(kindArg)) {
+    console.error(`✗ Unknown kind: ${kindArg}. Must be one of: ${validKinds.join(", ")}`);
+    process.exit(1);
+  }
+
+  let limitNum = 10;
+  if (limitStr !== undefined) {
+    const parsed = Number(limitStr);
+    if (!Number.isFinite(parsed)) {
+      console.error(`✗ --limit must be a number, got: ${limitStr}`);
+      process.exit(1);
+    }
+    limitNum = Math.floor(parsed);
+  }
+
+  await withDb(async (db) => {
+    let repoMeta: Array<{ id: unknown; name_with_owner: string }>;
+
+    if (repoArg) {
+      const [rows] = await db.query<[Array<{ id: unknown; name_with_owner: string }>]>(
+        "SELECT id, name_with_owner FROM repo WHERE name_with_owner = $nwo AND registered_at != NONE",
+        { nwo: repoArg },
+      );
+      if (rows.length === 0) {
+        console.error(`✗ Repo '${repoArg}' not registered — use \`tool add\` first`);
+        process.exit(1);
+      }
+      repoMeta = rows;
+    } else {
+      const [rows] = await db.query<[Array<{ id: unknown; name_with_owner: string }>]>(
+        "SELECT id, name_with_owner FROM repo WHERE registered_at != NONE",
+      );
+      repoMeta = rows;
+    }
+
+    if (repoMeta.length === 0) {
+      if (jsonFlag) {
+        console.log("[]");
+      } else {
+        console.log("(no registered repos — use `tool add <owner/name>` to register one)");
+      }
+      return;
+    }
+
+    const repoRefs = repoMeta.map((r) => new StringRecordId(String(r.id)));
+    const repoNwoById = new Map(repoMeta.map((r) => [String(r.id), r.name_with_owner]));
+
+    let vec: number[];
+    try {
+      vec = await embed(query);
+    } catch (err) {
+      console.error(`✗ Ollama not reachable: ${err}`);
+      process.exit(1);
+    }
+
+    const activeKinds: SearchKind[] =
+      kindArg === "all"
+        ? ["issue", "pull_request", "discussion", "comment"]
+        : [kindArg as SearchKind];
+
+    const allResults: SearchResult[] = [];
+
+    for (const kind of activeKinds) {
+      if (kind === "comment") continue;
+
+      const [rows] = await db.query<
+        [
+          Array<{
+            id: unknown;
+            number: number;
+            title: string;
+            github_url: string;
+            repo: unknown;
+            score: number;
+          }>,
+        ]
+      >(
+        `SELECT id, number, title, github_url, repo,
+           vector::similarity::cosine(embedding, $vec) AS score
+         FROM ${kind}
+         WHERE embedding != NONE
+           AND deleted_at IS NONE
+           AND repo IN $repos
+         ORDER BY score DESC LIMIT $limit`,
+        { vec, repos: repoRefs, limit: limitNum },
+      );
+
+      for (const row of rows) {
+        const nwo = repoNwoById.get(String(row.repo)) ?? String(row.repo);
+        allResults.push({
+          kind,
+          repo: nwo,
+          number: row.number,
+          title: row.title,
+          url: row.github_url,
+          score: row.score,
+        });
+      }
+    }
+
+    if (activeKinds.includes("comment")) {
+      const [issueIdRows] = await db.query<[Array<{ id: unknown }>]>(
+        "SELECT id FROM issue WHERE repo IN $repos AND deleted_at IS NONE",
+        { repos: repoRefs },
+      );
+      const [prIdRows] = await db.query<[Array<{ id: unknown }>]>(
+        "SELECT id FROM pull_request WHERE repo IN $repos AND deleted_at IS NONE",
+        { repos: repoRefs },
+      );
+      const [discIdRows] = await db.query<[Array<{ id: unknown }>]>(
+        "SELECT id FROM discussion WHERE repo IN $repos AND deleted_at IS NONE",
+        { repos: repoRefs },
+      );
+
+      const issueIds = issueIdRows.map((r) => new StringRecordId(String(r.id)));
+      const prIds = prIdRows.map((r) => new StringRecordId(String(r.id)));
+      const discIds = discIdRows.map((r) => new StringRecordId(String(r.id)));
+
+      if (issueIds.length > 0 || prIds.length > 0 || discIds.length > 0) {
+        const [commentRows] = await db.query<
+          [
+            Array<{
+              id: unknown;
+              github_url: string;
+              parent_issue: unknown;
+              parent_pr: unknown;
+              parent_discussion: unknown;
+              score: number;
+            }>,
+          ]
+        >(
+          `SELECT id, github_url, parent_issue, parent_pr, parent_discussion,
+             vector::similarity::cosine(embedding, $vec) AS score
+           FROM comment
+           WHERE embedding != NONE
+             AND deleted_at IS NONE
+             AND (parent_issue IN $issueIds OR parent_pr IN $prIds OR parent_discussion IN $discIds)
+           ORDER BY score DESC LIMIT $limit`,
+          { vec, issueIds, prIds, discIds, limit: limitNum },
+        );
+
+        for (const comment of commentRows) {
+          let parentKind: EntityKind;
+          let parentRef: StringRecordId;
+
+          if (comment.parent_issue) {
+            parentKind = "issue";
+            parentRef = new StringRecordId(String(comment.parent_issue));
+          } else if (comment.parent_pr) {
+            parentKind = "pull_request";
+            parentRef = new StringRecordId(String(comment.parent_pr));
+          } else {
+            parentKind = "discussion";
+            parentRef = new StringRecordId(String(comment.parent_discussion));
+          }
+
+          const [parentRows] = await db.query<
+            [Array<{ number: number; title: string; github_url: string; repo: unknown }>]
+          >(`SELECT number, title, github_url, repo FROM $id`, { id: parentRef });
+
+          if (parentRows.length === 0) continue;
+          const parent = parentRows[0];
+          const nwo = repoNwoById.get(String(parent.repo)) ?? String(parent.repo);
+
+          allResults.push({
+            kind: "comment",
+            subkind: parentKind,
+            repo: nwo,
+            number: parent.number,
+            title: `(comment on) ${parent.title}`,
+            url: comment.github_url,
+            score: comment.score,
+          });
+        }
+      }
+    }
+
+    allResults.sort((a, b) => b.score - a.score);
+    const results = allResults.slice(0, limitNum);
+
+    if (jsonFlag) {
+      console.log(
+        JSON.stringify(
+          results.map((r) => {
+            const obj: Record<string, unknown> = {
+              kind: r.kind,
+              repo: r.repo,
+              number: r.number,
+              title: r.title,
+              url: r.url,
+              score: r.score,
+            };
+            if (r.kind === "comment") {
+              obj.subkind = r.subkind;
+            }
+            return obj;
+          }),
+        ),
+      );
+      return;
+    }
+
+    if (results.length === 0) {
+      console.log(
+        "(no matches — try a different query, or run `tool sync`/`tool embed` first)",
+      );
+      return;
+    }
+
+    for (let i = 0; i < results.length; i++) {
+      const r = results[i];
+      let kindLabel: string;
+      if (r.kind === "pull_request") {
+        kindLabel = "pr";
+      } else if (r.kind === "comment") {
+        const subLabel = r.subkind === "pull_request" ? "pr" : r.subkind;
+        kindLabel = `comment on ${subLabel}`;
+      } else {
+        kindLabel = r.kind;
+      }
+      console.log(`${i + 1}. [${kindLabel}] ${r.title} (${r.repo}) — score: ${r.score.toFixed(4)}`);
+      console.log(`   ${r.url}`);
+      if (i < results.length - 1) console.log("");
+    }
+  });
+}


### PR DESCRIPTION
## Summary

`tool search` — first agent-facing read command. Takes a natural-language query, embeds it via Ollama, runs vector-similarity searches across registered repos, ranks results across kinds (issue / pull_request / discussion / comment), and returns top-N.

```sh
tool search "embedding provider returns null"
tool search "embedding provider returns null" --repo lfnovo/esperanto --json
tool search "embedding provider returns null" --kind issue --limit 5
```

Outputs human-readable text by default; `--json` emits stable shape for agent parsers.

## Code-review patch

Small inline fix on top of harny's output: comment results now keep the parent's raw title in JSON, and the `(comment on)` prefix is added only at human-render time. JSON consumers already have `kind: "comment"` + `subkind`; the prefix was redundant noise on the data.

## Test plan

- [x] `bun run typecheck && bun test` — 107/107 pass across 17 files (10 new test cases covering happy path, `--json`, `--repo` scope, `--kind` filter, `--limit`, empty matches, unregistered repo, Ollama down, bot-author skip, comment results).
- [ ] **Manual end-to-end** against the live `lfnovo/esperanto` mirror — to be run after merge:
  ```
  tool search "embedding provider returns null"
  ```
  Expected: issue #119 ("Embedding providers crash on null values...") as top match (validated to score ~0.77 during First Full Sync e2e).
- [ ] `bun run smoke:*` (manual; unaffected).

## Architectural notes

- **Read-style command**: ships `--json` from day one per the principle. Always exits 0 on success.
- **Cross-repo search by default**; `--repo` opt-in to scope to one repo.
- **Bot-authored items naturally absent**: their `embedding` is always `NONE` per the bot policy, so the `WHERE embedding != NONE` filter excludes them.
- **Tombstoned items absent**: `WHERE deleted_at IS NONE`.
- **Comment results enrich** with the parent's title and number; URL points to the comment anchor on GitHub.

## Out of scope

- Hybrid (keyword + vector) ranking.
- Reranking with a cross-encoder.
- Pagination beyond `--limit`.
- Showing comment body excerpts in results.

Closes #39


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `tool search`, a semantic search CLI that embeds a natural-language query via `Ollama`, runs cosine-similarity across mirrored repos, and returns the most relevant issues, PRs, discussions, and comments. Outputs human-readable text by default and stable JSON for agents with `--json`.

- **New Features**
  - Command: `tool search "query" [--repo owner/name] [--kind issue|pull_request|discussion|comment|all] [--limit N] [--json]`.
  - Cross-repo by default; `--repo` scopes to a single repo. Results ranked by cosine similarity; top-N via `--limit`.
  - Filters out bot-authored items (no embeddings) and tombstoned records. Comment results include parent number/title and link to the comment anchor. JSON includes `subkind` for comments.
  - Help updated to list the new command.

- **Bug Fixes**
  - JSON keeps the parent’s raw title for comment results; the "(comment on)" label is added only in human-readable output.

<sup>Written for commit 6d4b5c8f33b19bd83e36b5afa34aabbc62c1aaf6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

