### PR TITLE
fix(search): use `array CONTAINS field` (SurrealDB v2 IN-with-records quirk)

### DIFF
--- a/src/commands/search.ts
+++ b/src/commands/search.ts
@@ -139,7 +139,7 @@ export default async function run(args: string[]): Promise<void> {
          FROM ${kind}
          WHERE embedding != NONE
            AND deleted_at IS NONE
-           AND repo IN $repos
+           AND $repos CONTAINS repo
          ORDER BY score DESC LIMIT $limit`,
         { vec, repos: repoRefs, limit: limitNum },
       );
@@ -159,15 +159,15 @@ export default async function run(args: string[]): Promise<void> {
 
     if (activeKinds.includes("comment")) {
       const [issueIdRows] = await db.query<[Array<{ id: unknown }>]>(
-        "SELECT id FROM issue WHERE repo IN $repos AND deleted_at IS NONE",
+        "SELECT id FROM issue WHERE $repos CONTAINS repo AND deleted_at IS NONE",
         { repos: repoRefs },
       );
       const [prIdRows] = await db.query<[Array<{ id: unknown }>]>(
-        "SELECT id FROM pull_request WHERE repo IN $repos AND deleted_at IS NONE",
+        "SELECT id FROM pull_request WHERE $repos CONTAINS repo AND deleted_at IS NONE",
         { repos: repoRefs },
       );
       const [discIdRows] = await db.query<[Array<{ id: unknown }>]>(
-        "SELECT id FROM discussion WHERE repo IN $repos AND deleted_at IS NONE",
+        "SELECT id FROM discussion WHERE $repos CONTAINS repo AND deleted_at IS NONE",
         { repos: repoRefs },
       );
 
@@ -193,7 +193,7 @@ export default async function run(args: string[]): Promise<void> {
            FROM comment
            WHERE embedding != NONE
              AND deleted_at IS NONE
-             AND (parent_issue IN $issueIds OR parent_pr IN $prIds OR parent_discussion IN $discIds)
+             AND ($issueIds CONTAINS parent_issue OR $prIds CONTAINS parent_pr OR $discIds CONTAINS parent_discussion)
            ORDER BY score DESC LIMIT $limit`,
           { vec, issueIds, prIds, discIds, limit: limitNum },
         );


### PR DESCRIPTION
Surfaced during first manual e2e of `tool search` against live data: `tool search ... --kind issue` returned `(no matches)` despite 73 embedded issues in the repo. The unit tests passed because they exercised the same broken syntax against in-memory data — false negative.

The bug: SurrealDB v2 (with `@surrealdb/wasm` engine) silently returns 0 results for `field IN $array` when the array contains `StringRecordId` values. No error, just empty result set. The reverse — `$array CONTAINS field` — works.

Two patches: scope filter on issue/pull_request/discussion (`$repos CONTAINS repo`) and the comment-parent filter (`$issueIds CONTAINS parent_issue OR ...`).

Adding to CLAUDE.md as a SurrealDB WASM gotcha is a follow-up if this surfaces a third time.

## Test plan
- [x] `bun run typecheck && bun test` — 107/107 pass.
- [x] **E2E**: `tool search "embedding provider returns null" --kind issue --limit 3` returns issue #119 as top result (score 0.7429), matching the validated e2e baseline.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes zero-result bug in `tool search` by replacing `field IN $array` with `$array CONTAINS field` to work around a SurrealDB v2 quirk with record IDs in `@surrealdb/wasm`. Results now return correctly for issues, PRs, discussions, and comments.

- **Bug Fixes**
  - Replace `repo IN $repos` with `$repos CONTAINS repo` in the main search query and per-kind ID lookups.
  - Replace `(parent_issue IN $issueIds OR ...)` with `($issueIds CONTAINS parent_issue OR ...)` in comment search.

<sup>Written for commit b1c74c7b032683a38016c0fa2f3627c950545e54. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

