### PR TITLE
feat(embed): halving-retry fallback for context-length errors

### DIFF
--- a/src/clients/ollama.test.ts
+++ b/src/clients/ollama.test.ts
@@ -30,16 +30,19 @@ function mockFetch(fn: (...args: any[]) => Promise<Response>): void {
   global.fetch = fn as typeof fetch;
 }
 
-describe("embedWithFallback — success on first try", () => {
-  it("returns the embedding vector directly", async () => {
-    mockFetch(async () => makeOkResponse([MOCK_VECTOR]));
+describe("embedWithFallback", () => {
+  it("returns embedding on first call with no retries (1 fetch call)", async () => {
+    let callCount = 0;
+    mockFetch(async () => {
+      callCount++;
+      return makeOkResponse([MOCK_VECTOR]);
+    });
     const result = await embedWithFallback("hello world");
     expect(result).toEqual(MOCK_VECTOR);
+    expect(callCount).toBe(1);
   });
-});
 
-describe("embedWithFallback — context-length error triggers halving", () => {
-  it("retries with half the text after context-length error and returns embedding", async () => {
+  it("halves text once on context-length error then succeeds (2 fetch calls)", async () => {
     let callCount = 0;
     mockFetch(async () => {
       callCount++;
@@ -47,38 +50,13 @@ describe("embedWithFallback — context-length error triggers halving", () => {
         return makeErrorResponse("input length exceeds the context length");
       return makeOkResponse([MOCK_VECTOR]);
     });
-    const text = "a".repeat(600);
+    const text = "a".repeat(8000);
     const result = await embedWithFallback(text);
     expect(result).toEqual(MOCK_VECTOR);
     expect(callCount).toBe(2);
   });
 
-  it("throws minimum-length error when len drops below 256", async () => {
-    mockFetch(async () =>
-      makeErrorResponse("input length exceeds the context length"),
-    );
-    const text = "a".repeat(600);
-    await expect(embedWithFallback(text)).rejects.toThrow(
-      "could not embed at any length: text exceeds context even at minimum",
-    );
-  });
-});
-
-describe("embedWithFallback — non-context errors propagate immediately", () => {
-  it("rethrows connection-refused error without retrying", async () => {
-    let callCount = 0;
-    mockFetch(async () => {
-      callCount++;
-      return makeErrorResponse("connection refused", 503);
-    });
-    const text = "a".repeat(600);
-    await expect(embedWithFallback(text)).rejects.toThrow("HTTP 503");
-    expect(callCount).toBe(1);
-  });
-});
-
-describe("isContextLengthError — verified through embedWithFallback behavior", () => {
-  it("treats 'input length exceeds the context length' as a context-length error (retries)", async () => {
+  it("halves text multiple times until success (3 fetch calls)", async () => {
     let callCount = 0;
     mockFetch(async () => {
       callCount++;
@@ -86,18 +64,37 @@ describe("isContextLengthError — verified through embedWithFallback behavior",
         return makeErrorResponse("input length exceeds the context length");
       return makeOkResponse([MOCK_VECTOR]);
     });
-    const text = "a".repeat(1200);
-    await embedWithFallback(text);
-    expect(callCount).toBeGreaterThan(1);
+    const text = "a".repeat(8000);
+    const result = await embedWithFallback(text);
+    expect(result).toEqual(MOCK_VECTOR);
+    expect(callCount).toBe(3);
   });
 
-  it("treats 'connection refused' as a non-context error (no retry)", async () => {
+  it("propagates non-context error immediately without retrying (1 fetch call)", async () => {
     let callCount = 0;
     mockFetch(async () => {
       callCount++;
-      return makeErrorResponse("connection refused", 503);
+      return makeErrorResponse("internal error", 500);
     });
-    await expect(embedWithFallback("a".repeat(600))).rejects.toThrow();
+    const text = "a".repeat(8000);
+    await expect(embedWithFallback(text)).rejects.toThrow("HTTP 500");
     expect(callCount).toBe(1);
+  });
+
+  it("throws 'could not embed at any length' after exhausting MIN_FALLBACK_CHARS", async () => {
+    let callCount = 0;
+    mockFetch(async () => {
+      callCount++;
+      return makeErrorResponse("input length exceeds the context length");
+    });
+    // Use a power of 2 so Math.floor halving is exact and the formula holds
+    const initialLen = 1024;
+    const text = "a".repeat(initialLen);
+    await expect(embedWithFallback(text)).rejects.toThrow(
+      "could not embed at any length",
+    );
+    // Each retry halves len; throws after floor(len/2) < 256
+    const expectedCalls = Math.ceil(Math.log2(initialLen / 256)) + 1;
+    expect(callCount).toBe(expectedCalls);
   });
 });

--- a/src/clients/ollama.test.ts
+++ b/src/clients/ollama.test.ts
@@ -97,4 +97,19 @@ describe("embedWithFallback", () => {
     const expectedCalls = Math.ceil(Math.log2(initialLen / 256)) + 1;
     expect(callCount).toBe(expectedCalls);
   });
+
+  it("retries at MIN_FALLBACK_CHARS when halving would skip past it", async () => {
+    let callCount = 0;
+    mockFetch(async () => {
+      callCount++;
+      return makeErrorResponse("input length exceeds the context length");
+    });
+    // 500 chars: halving gives 250 (< 256), but the fallback should clamp to
+    // 256 and try once more before giving up.
+    const text = "a".repeat(500);
+    await expect(embedWithFallback(text)).rejects.toThrow(
+      "could not embed at any length",
+    );
+    expect(callCount).toBe(2);
+  });
 });

--- a/src/clients/ollama.test.ts
+++ b/src/clients/ollama.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { embedWithFallback } from "./ollama.ts";
+
+const EMBED_DIM = 768;
+const MOCK_VECTOR = new Array(EMBED_DIM).fill(0.1);
+
+function makeOkResponse(vectors: number[][]): Response {
+  return new Response(JSON.stringify({ embeddings: vectors }), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function makeErrorResponse(body: string, status = 400): Response {
+  return new Response(body, { status });
+}
+
+let originalFetch: typeof fetch;
+
+beforeEach(() => {
+  originalFetch = global.fetch;
+});
+
+afterEach(() => {
+  global.fetch = originalFetch;
+});
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function mockFetch(fn: (...args: any[]) => Promise<Response>): void {
+  global.fetch = fn as typeof fetch;
+}
+
+describe("embedWithFallback — success on first try", () => {
+  it("returns the embedding vector directly", async () => {
+    mockFetch(async () => makeOkResponse([MOCK_VECTOR]));
+    const result = await embedWithFallback("hello world");
+    expect(result).toEqual(MOCK_VECTOR);
+  });
+});
+
+describe("embedWithFallback — context-length error triggers halving", () => {
+  it("retries with half the text after context-length error and returns embedding", async () => {
+    let callCount = 0;
+    mockFetch(async () => {
+      callCount++;
+      if (callCount === 1)
+        return makeErrorResponse("input length exceeds the context length");
+      return makeOkResponse([MOCK_VECTOR]);
+    });
+    const text = "a".repeat(600);
+    const result = await embedWithFallback(text);
+    expect(result).toEqual(MOCK_VECTOR);
+    expect(callCount).toBe(2);
+  });
+
+  it("throws minimum-length error when len drops below 256", async () => {
+    mockFetch(async () =>
+      makeErrorResponse("input length exceeds the context length"),
+    );
+    const text = "a".repeat(600);
+    await expect(embedWithFallback(text)).rejects.toThrow(
+      "could not embed at any length: text exceeds context even at minimum",
+    );
+  });
+});
+
+describe("embedWithFallback — non-context errors propagate immediately", () => {
+  it("rethrows connection-refused error without retrying", async () => {
+    let callCount = 0;
+    mockFetch(async () => {
+      callCount++;
+      return makeErrorResponse("connection refused", 503);
+    });
+    const text = "a".repeat(600);
+    await expect(embedWithFallback(text)).rejects.toThrow("HTTP 503");
+    expect(callCount).toBe(1);
+  });
+});
+
+describe("isContextLengthError — verified through embedWithFallback behavior", () => {
+  it("treats 'input length exceeds the context length' as a context-length error (retries)", async () => {
+    let callCount = 0;
+    mockFetch(async () => {
+      callCount++;
+      if (callCount < 3)
+        return makeErrorResponse("input length exceeds the context length");
+      return makeOkResponse([MOCK_VECTOR]);
+    });
+    const text = "a".repeat(1200);
+    await embedWithFallback(text);
+    expect(callCount).toBeGreaterThan(1);
+  });
+
+  it("treats 'connection refused' as a non-context error (no retry)", async () => {
+    let callCount = 0;
+    mockFetch(async () => {
+      callCount++;
+      return makeErrorResponse("connection refused", 503);
+    });
+    await expect(embedWithFallback("a".repeat(600))).rejects.toThrow();
+    expect(callCount).toBe(1);
+  });
+});

--- a/src/clients/ollama.ts
+++ b/src/clients/ollama.ts
@@ -1,5 +1,11 @@
 import { config } from "../config.ts";
 
+const MIN_FALLBACK_CHARS = 256;
+
+function isContextLengthError(err: unknown): boolean {
+  return err instanceof Error && /context length/i.test(err.message);
+}
+
 export async function embedMany(texts: string[]): Promise<number[][]> {
   const url = `${config.OLLAMA_URL}/api/embed`;
   const response = await fetch(url, {
@@ -33,4 +39,22 @@ export async function embedMany(texts: string[]): Promise<number[][]> {
 export async function embed(text: string): Promise<number[]> {
   const result = await embedMany([text]);
   return result[0];
+}
+
+export async function embedWithFallback(text: string): Promise<number[]> {
+  let len = text.length;
+  while (true) {
+    try {
+      const result = await embedMany([text.slice(0, len)]);
+      return result[0];
+    } catch (err) {
+      if (!isContextLengthError(err)) throw err;
+      len = Math.floor(len / 2);
+      if (len < MIN_FALLBACK_CHARS) {
+        throw new Error(
+          "could not embed at any length: text exceeds context even at minimum",
+        );
+      }
+    }
+  }
 }

--- a/src/clients/ollama.ts
+++ b/src/clients/ollama.ts
@@ -49,12 +49,12 @@ export async function embedWithFallback(text: string): Promise<number[]> {
       return result[0];
     } catch (err) {
       if (!isContextLengthError(err)) throw err;
-      len = Math.floor(len / 2);
-      if (len < MIN_FALLBACK_CHARS) {
+      if (len <= MIN_FALLBACK_CHARS) {
         throw new Error(
           "could not embed at any length: text exceeds context even at minimum",
         );
       }
+      len = Math.max(MIN_FALLBACK_CHARS, Math.floor(len / 2));
     }
   }
 }

--- a/src/commands/embed.test.ts
+++ b/src/commands/embed.test.ts
@@ -8,6 +8,8 @@ let embedManyCallCount = 0;
 let embedManyImpl: (texts: string[]) => Promise<number[][]> = async (texts) =>
   texts.map(() => new Array(768).fill(0.1));
 let embedProbeImpl: () => Promise<number[]> = async () => new Array(768).fill(0.1);
+let embedWithFallbackImpl: (text: string) => Promise<number[]> = async () =>
+  new Array(768).fill(0.1);
 
 mock.module("../clients/ollama.ts", () => ({
   embed: (_text: string) => embedProbeImpl(),
@@ -15,6 +17,7 @@ mock.module("../clients/ollama.ts", () => ({
     embedManyCallCount++;
     return embedManyImpl(texts);
   },
+  embedWithFallback: (text: string) => embedWithFallbackImpl(text),
 }));
 
 mock.module("../clients/surreal.ts", () => ({
@@ -389,6 +392,9 @@ describe("embed command — per-item failure after first success", () => {
         if (callIndex === 1) return texts.map(() => new Array(768).fill(0.5));
         throw new Error("embedding service error");
       };
+      embedWithFallbackImpl = async () => {
+        throw new Error("embedding service error");
+      };
       embedProbeImpl = async () => new Array(768).fill(0.1);
 
       const { repoId, nwo } = await seedRepoAndOrg(db, "PF");
@@ -452,6 +458,56 @@ describe("embed command — per-item failure after first success", () => {
         "SELECT embedding FROM pull_request WHERE github_node_id = 'PR_PF_1'",
       );
       expect(pr.embedding == null).toBe(true);
+    });
+    testDb = null;
+  });
+});
+
+describe("embed command — per-item oversize recovery", () => {
+  it("embeds item via embedWithFallback when batch fails with context-length error", async () => {
+    await withTestDb(async (db) => {
+      testDb = db;
+      embedManyCallCount = 0;
+      embedManyImpl = async () => {
+        throw new Error("context length exceeded");
+      };
+      embedWithFallbackImpl = async () => new Array(768).fill(0.7);
+      embedProbeImpl = async () => new Array(768).fill(0.1);
+
+      const { repoId, nwo } = await seedRepoAndOrg(db, "OR");
+      const repoRef = new StringRecordId(String(repoId));
+
+      await db.query(
+        `CREATE issue CONTENT {
+          github_node_id: 'I_OR_1',
+          github_url: 'u',
+          repo: $repo,
+          number: 1,
+          title: 'Oversize Issue',
+          body: 'body',
+          state: 'OPEN',
+          author: NONE,
+          created_at: time::now(),
+          updated_at: time::now(),
+          deleted_at: NONE,
+          content_hash: 'hash_or',
+          embedding: NONE,
+          embedded_content_hash: NONE
+        }`,
+        { repo: repoRef },
+      );
+
+      const { exitCode } = await runCapturingExit(() => run([nwo]));
+      expect(exitCode).toBeUndefined();
+
+      const [[issue]] = await db.query<
+        [[{ embedding: unknown; embedded_content_hash: string }]]
+      >(
+        "SELECT embedding, embedded_content_hash FROM issue WHERE github_node_id = 'I_OR_1'",
+      );
+      expect(issue.embedding).not.toBeNull();
+      expect(issue.embedding).not.toBeUndefined();
+      expect(issue.embedded_content_hash).toBe("hash_or");
     });
     testDb = null;
   });

--- a/src/commands/embed.ts
+++ b/src/commands/embed.ts
@@ -1,5 +1,5 @@
 import { withDb } from "../clients/surreal.ts";
-import { embed, embedMany } from "../clients/ollama.ts";
+import { embed, embedMany, embedWithFallback } from "../clients/ollama.ts";
 import { embedText } from "../ingest/embed_text.ts";
 import { StringRecordId } from "surrealdb";
 import { config } from "../config.ts";
@@ -101,8 +101,8 @@ export default async function run(args: string[]): Promise<void> {
           // Fall back to per-item embedding to isolate the offender.
           for (let j = 0; j < texts.length; j++) {
             try {
-              const single = await embedMany([texts[j]]);
-              vectors.push(single[0]);
+              const single = await embedWithFallback(texts[j]);
+              vectors.push(single);
             } catch (perItemErr) {
               if (successCount === 0) {
                 consecutiveFailsFromStart++;

--- a/src/ingest/embed_text.test.ts
+++ b/src/ingest/embed_text.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "bun:test";
-import { embedText, EMBED_TEXT_MAX_CHARS } from "./embed_text";
+import { embedText } from "./embed_text";
 
 describe("embedText", () => {
   it("joins title and body with double newline", () => {
@@ -16,16 +16,5 @@ describe("embedText", () => {
 
   it("normalises CRLF in body", () => {
     expect(embedText({ title: "T", body: "Body with\r\nCRLF" })).toBe("T\n\nBody with\nCRLF");
-  });
-
-  it("truncates inputs longer than EMBED_TEXT_MAX_CHARS", () => {
-    const longBody = "x".repeat(EMBED_TEXT_MAX_CHARS + 100);
-    const out = embedText({ title: null, body: longBody });
-    expect(out.length).toBe(EMBED_TEXT_MAX_CHARS);
-  });
-
-  it("does not truncate inputs at or below the cap", () => {
-    const exact = "x".repeat(EMBED_TEXT_MAX_CHARS);
-    expect(embedText({ title: null, body: exact }).length).toBe(EMBED_TEXT_MAX_CHARS);
   });
 });

--- a/src/ingest/embed_text.ts
+++ b/src/ingest/embed_text.ts
@@ -1,20 +1,5 @@
-// Hard cap to stay inside `nomic-embed-text`'s 8192-token context window.
-// 6000 chars is the empirically-determined safe figure for this corpus:
-// the densest item in lfnovo/esperanto (a 7995-char comment) exceeds the
-// context at 7000+ chars but works at ≤ 6500. We pick 6000 for headroom.
-//
-// At 8192 tokens / 6000 chars ≈ 1.4 tokens/char, this is conservative for
-// most real-world text. Items longer than the cap lose their tail in the
-// embedding only — the full body is preserved on the row for retrieval-
-// time access.
-//
-// Future, when long-item retrieval quality matters: chunk into multiple
-// embeddings per item (open in VISION).
-export const EMBED_TEXT_MAX_CHARS = 6000;
-
 export function embedText(node: { title?: string | null; body: string | null }): string {
   const title = node.title ?? "";
   const body = (node.body ?? "").replace(/\r\n/g, "\n");
-  const full = title ? `${title}\n\n${body}` : body;
-  return full.length > EMBED_TEXT_MAX_CHARS ? full.slice(0, EMBED_TEXT_MAX_CHARS) : full;
+  return title ? `${title}\n\n${body}` : body;
 }


### PR DESCRIPTION
## Summary

Replace the empirically-tuned `EMBED_TEXT_MAX_CHARS = 6000` cap with a halving-retry fallback that defers to the Ollama server as the source of truth for context limits. Adds `embedWithFallback(text)` to `src/clients/ollama.ts`: starts at full length, halves on context-length errors, throws at `MIN_FALLBACK_CHARS = 256` if the text still doesn't fit. Non-context errors propagate immediately.

The per-item fallback in `tool embed` (post-#37) now calls `embedWithFallback`, so individual stubborn items get the halving treatment automatically. `embedText` returns the full canonical string — no offline truncation.

## Changes

- `src/clients/ollama.ts` — adds `isContextLengthError` (internal) and `embedWithFallback` (exported).
- `src/clients/ollama.test.ts` (new) — 5 tests: happy path, halves once, halves multiple, non-context error propagation, exhaustion at minimum length.
- `src/commands/embed.ts` — per-item fallback now calls `embedWithFallback(text)` instead of `embedMany([text])`.
- `src/commands/embed.test.ts` — adds `embedWithFallbackImpl` mock; new "per-item oversize recovery" test.
- `src/ingest/embed_text.ts` — drops `EMBED_TEXT_MAX_CHARS` and the truncation slice.
- `src/ingest/embed_text.test.ts` — drops the two truncation-specific tests.

## Test plan

- [x] `bun run typecheck` — clean.
- [x] `bun test` — 111 pass, 0 fail across 18 files.
- [x] No new runtime dependencies (`git diff main -- package.json bun.lockb` empty).
- [ ] Manual smoke (live infra): `tool embed lfnovo/esperanto` ends with `0 failed`; PR `PR_kwDONT0hi87QBrIC` (the previously-unembeddable item) now has a non-null embedding. **To be run after merge** (requires live Ollama + populated SurrealDB).

Closes #38

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a halving-retry fallback for Ollama context-length errors and removes offline truncation, so embeddings succeed more often while preserving full text. The `embed` command now applies this per-item, closing #38 by deferring to the server’s true context limit.

- **New Features**
  - Added `embedWithFallback(text)` that halves on context-length errors and clamps to 256 chars for a final attempt; other errors bubble.
  - Updated per-item fallback in `tool embed` to call `embedWithFallback`, recovering oversized items.

- **Refactors**
  - Removed `EMBED_TEXT_MAX_CHARS` and truncation from `embedText`; we now embed the full canonical string.
  - Added tests for fallback behavior and per-item oversize recovery; removed truncation tests.

<sup>Written for commit 8a4858be0ba01a6b298aea33be5dae192d527679. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

