### PR TITLE
refactor(clients): extract updateSet/createContent for SurrealQL tri-state fields

### DIFF
--- a/src/clients/surreal_helpers.test.ts
+++ b/src/clients/surreal_helpers.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test } from "bun:test";
+import { createContent, updateSet } from "./surreal_helpers.ts";
+
+describe("updateSet", () => {
+  test("concrete value binds via $fieldName", () => {
+    const result = updateSet({ title: "hello" });
+    expect(result).toEqual({ sql: "SET title = $title", params: { title: "hello" } });
+  });
+
+  test("null inlines NONE", () => {
+    const result = updateSet({ body: null });
+    expect(result).toEqual({ sql: "SET body = NONE", params: {} });
+  });
+
+  test("undefined skips the field entirely", () => {
+    const result = updateSet({ author: undefined });
+    expect(result).toEqual({ sql: "SET ", params: {} });
+  });
+
+  test("mixed: concrete value, null, undefined", () => {
+    const result = updateSet({ title: "hello", body: null, author: undefined });
+    expect(result).toEqual({
+      sql: "SET title = $title, body = NONE",
+      params: { title: "hello" },
+    });
+  });
+
+  test("number value binds via $fieldName", () => {
+    const result = updateSet({ number: 42 });
+    expect(result).toEqual({ sql: "SET number = $number", params: { number: 42 } });
+  });
+
+  test("Date value binds via $fieldName", () => {
+    const date = new Date("2024-01-01T00:00:00Z");
+    const result = updateSet({ created_at: date });
+    expect(result).toEqual({ sql: "SET created_at = $created_at", params: { created_at: date } });
+  });
+
+  test("all fields undefined returns empty SET clause", () => {
+    const result = updateSet({ a: undefined, b: undefined });
+    expect(result.sql).toBe("SET ");
+    expect(result.params).toEqual({});
+  });
+});
+
+describe("createContent", () => {
+  test("concrete value binds via $fieldName", () => {
+    const result = createContent({ github_node_id: "abc" });
+    expect(result).toEqual({
+      sql: "{ github_node_id: $github_node_id }",
+      params: { github_node_id: "abc" },
+    });
+  });
+
+  test("null inlines NONE", () => {
+    const result = createContent({ body: null });
+    expect(result).toEqual({ sql: "{ body: NONE }", params: {} });
+  });
+
+  test("undefined skips the field entirely", () => {
+    const result = createContent({ author: undefined });
+    expect(result).toEqual({ sql: "{  }", params: {} });
+  });
+
+  test("mixed: concrete value, null, undefined", () => {
+    const result = createContent({ github_node_id: "abc", body: null, author: undefined });
+    expect(result).toEqual({
+      sql: "{ github_node_id: $github_node_id, body: NONE }",
+      params: { github_node_id: "abc" },
+    });
+  });
+
+  test("number value binds via $fieldName", () => {
+    const result = createContent({ count: 5 });
+    expect(result).toEqual({ sql: "{ count: $count }", params: { count: 5 } });
+  });
+
+  test("boolean value binds via $fieldName", () => {
+    const result = createContent({ active: true });
+    expect(result).toEqual({ sql: "{ active: $active }", params: { active: true } });
+  });
+});

--- a/src/clients/surreal_helpers.test.ts
+++ b/src/clients/surreal_helpers.test.ts
@@ -41,6 +41,11 @@ describe("updateSet", () => {
     expect(result.sql).toBe("SET ");
     expect(result.params).toEqual({});
   });
+
+  test("empty input {} produces empty SET clause", () => {
+    const result = updateSet({});
+    expect(result).toEqual({ sql: "SET ", params: {} });
+  });
 });
 
 describe("createContent", () => {
@@ -78,5 +83,11 @@ describe("createContent", () => {
   test("boolean value binds via $fieldName", () => {
     const result = createContent({ active: true });
     expect(result).toEqual({ sql: "{ active: $active }", params: { active: true } });
+  });
+
+  test("empty input {} produces empty content literal", () => {
+    const result = createContent({});
+    expect(result.sql).toMatch(/^\{[\s]*\}$/);
+    expect(result.params).toEqual({});
   });
 });

--- a/src/clients/surreal_helpers.ts
+++ b/src/clients/surreal_helpers.ts
@@ -1,0 +1,52 @@
+export type FieldValue = string | number | boolean | Date | object | null | undefined;
+
+export interface FieldsResult {
+  sql: string;
+  params: Record<string, unknown>;
+}
+
+/**
+ * Builds a SurrealQL SET clause from a plain JS object using tri-state semantics:
+ * - concrete value → binds via $fieldName and appears in params
+ * - null → inlines the SurrealQL literal NONE
+ * - undefined → skips the field entirely
+ */
+export function updateSet(fields: Record<string, FieldValue>): FieldsResult {
+  const parts: string[] = [];
+  const params: Record<string, unknown> = {};
+
+  for (const [key, value] of Object.entries(fields)) {
+    if (value === undefined) continue;
+    if (value === null) {
+      parts.push(`${key} = NONE`);
+    } else {
+      parts.push(`${key} = $${key}`);
+      params[key] = value;
+    }
+  }
+
+  return { sql: `SET ${parts.join(", ")}`, params };
+}
+
+/**
+ * Builds a SurrealQL CONTENT object literal from a plain JS object using tri-state semantics:
+ * - concrete value → binds via $fieldName and appears in params
+ * - null → inlines the SurrealQL literal NONE
+ * - undefined → skips the field entirely
+ */
+export function createContent(fields: Record<string, FieldValue>): FieldsResult {
+  const parts: string[] = [];
+  const params: Record<string, unknown> = {};
+
+  for (const [key, value] of Object.entries(fields)) {
+    if (value === undefined) continue;
+    if (value === null) {
+      parts.push(`${key}: NONE`);
+    } else {
+      parts.push(`${key}: $${key}`);
+      params[key] = value;
+    }
+  }
+
+  return { sql: `{ ${parts.join(", ")} }`, params };
+}

--- a/src/commands/add.ts
+++ b/src/commands/add.ts
@@ -1,5 +1,6 @@
 import { gh } from "../clients/github.ts";
 import { withDb } from "../clients/surreal.ts";
+import { createContent, updateSet } from "../clients/surreal_helpers.ts";
 
 type GitHubOwner = {
   __typename: "Organization" | "User";
@@ -83,45 +84,33 @@ export default async function run(args: string[]): Promise<void> {
 
     let orgId: unknown;
     if (existingOrgs.length === 0) {
+      const orgContent = createContent({
+        github_node_id: owner.id,
+        github_url: owner.url,
+        login: owner.login,
+        name: owner.name,
+        kind: owner.__typename,
+        created_at: new Date(owner.createdAt),
+        updated_at: new Date(owner.updatedAt),
+        deleted_at: null,
+      });
       const [created] = await db.query<[Array<{ id: unknown }>]>(
-        `CREATE org CONTENT {
-          github_node_id: $github_node_id,
-          github_url: $github_url,
-          login: $login,
-          name: $name,
-          kind: $kind,
-          created_at: $created_at,
-          updated_at: $updated_at,
-          deleted_at: NONE
-        }`,
-        {
-          github_node_id: owner.id,
-          github_url: owner.url,
-          login: owner.login,
-          name: owner.name,
-          kind: owner.__typename,
-          created_at: new Date(owner.createdAt),
-          updated_at: new Date(owner.updatedAt),
-        },
+        `CREATE org CONTENT ${orgContent.sql}`,
+        orgContent.params,
       );
       orgId = created[0].id;
     } else {
       orgId = existingOrgs[0].id;
+      const orgSet = updateSet({
+        github_url: owner.url,
+        login: owner.login,
+        name: owner.name,
+        kind: owner.__typename,
+        updated_at: new Date(owner.updatedAt),
+      });
       await db.query(
-        `UPDATE $id SET
-          github_url = $github_url,
-          login = $login,
-          name = $name,
-          kind = $kind,
-          updated_at = $updated_at`,
-        {
-          id: orgId,
-          github_url: owner.url,
-          login: owner.login,
-          name: owner.name,
-          kind: owner.__typename,
-          updated_at: new Date(owner.updatedAt),
-        },
+        `UPDATE $id ${orgSet.sql}`,
+        { id: orgId, ...orgSet.params },
       );
     }
 
@@ -135,30 +124,20 @@ export default async function run(args: string[]): Promise<void> {
 
     let repoId: unknown;
     if (existingRepos.length === 0) {
+      const repoContent = createContent({
+        github_node_id: repository.id,
+        github_url: repository.url,
+        name: repoName,
+        name_with_owner: repository.nameWithOwner,
+        description: repository.description,
+        is_private: repository.isPrivate,
+        owner: orgId as object,
+        created_at: new Date(repository.createdAt),
+        updated_at: new Date(repository.updatedAt),
+      });
       const [created] = await db.query<[Array<{ id: unknown }>]>(
-        `CREATE repo CONTENT {
-          github_node_id: $github_node_id,
-          github_url: $github_url,
-          name: $name,
-          name_with_owner: $name_with_owner,
-          description: $description,
-          is_private: $is_private,
-          owner: $owner,
-          created_at: $created_at,
-          updated_at: $updated_at,
-          registered_at: time::now()
-        }`,
-        {
-          github_node_id: repository.id,
-          github_url: repository.url,
-          name: repoName,
-          name_with_owner: repository.nameWithOwner,
-          description: repository.description,
-          is_private: repository.isPrivate,
-          owner: orgId,
-          created_at: new Date(repository.createdAt),
-          updated_at: new Date(repository.updatedAt),
-        },
+        `CREATE repo CONTENT ${repoContent.sql.slice(0, -2)}, registered_at: time::now() }`,
+        repoContent.params,
       );
       repoId = created[0].id;
     } else {
@@ -166,54 +145,30 @@ export default async function run(args: string[]): Promise<void> {
       repoId = existingRepo.id;
       const hasRegisteredAt = existingRepo.registered_at != null;
 
+      const repoFields = {
+        github_url: repository.url,
+        name: repoName,
+        name_with_owner: repository.nameWithOwner,
+        description: repository.description,
+        is_private: repository.isPrivate,
+        owner: orgId as object,
+        created_at: new Date(repository.createdAt),
+        updated_at: new Date(repository.updatedAt),
+      };
+
       if (hasRegisteredAt) {
         // Preserve existing registered_at — do not overwrite
+        const repoSet = updateSet(repoFields);
         await db.query(
-          `UPDATE $id SET
-            github_url = $github_url,
-            name = $name,
-            name_with_owner = $name_with_owner,
-            description = $description,
-            is_private = $is_private,
-            owner = $owner,
-            created_at = $created_at,
-            updated_at = $updated_at`,
-          {
-            id: repoId,
-            github_url: repository.url,
-            name: repoName,
-            name_with_owner: repository.nameWithOwner,
-            description: repository.description,
-            is_private: repository.isPrivate,
-            owner: orgId,
-            created_at: new Date(repository.createdAt),
-            updated_at: new Date(repository.updatedAt),
-          },
+          `UPDATE $id ${repoSet.sql}`,
+          { id: repoId, ...repoSet.params },
         );
       } else {
         // registered_at was NONE — set it now to re-register
+        const repoSet = updateSet(repoFields);
         await db.query(
-          `UPDATE $id SET
-            github_url = $github_url,
-            name = $name,
-            name_with_owner = $name_with_owner,
-            description = $description,
-            is_private = $is_private,
-            owner = $owner,
-            created_at = $created_at,
-            updated_at = $updated_at,
-            registered_at = time::now()`,
-          {
-            id: repoId,
-            github_url: repository.url,
-            name: repoName,
-            name_with_owner: repository.nameWithOwner,
-            description: repository.description,
-            is_private: repository.isPrivate,
-            owner: orgId,
-            created_at: new Date(repository.createdAt),
-            updated_at: new Date(repository.updatedAt),
-          },
+          `UPDATE $id ${repoSet.sql}, registered_at = time::now()`,
+          { id: repoId, ...repoSet.params },
         );
       }
     }

--- a/src/commands/search.test.ts
+++ b/src/commands/search.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, mock } from "bun:test";
 import type { Surreal } from "surrealdb";
 import { StringRecordId } from "surrealdb";
 import { withTestDb } from "../test_utils/with_test_db.ts";
+import { createContent } from "../clients/surreal_helpers.ts";
 
 let testDb: Surreal | null = null;
 let embedImpl: () => Promise<number[]> = async () => VEC_QUERY.slice();
@@ -102,33 +103,23 @@ async function seedIssue(
   suffix: string,
   opts: { number: number; title: string; embedding: number[] | null },
 ) {
-  const embeddingExpr = opts.embedding !== null ? "$embedding" : "NONE";
+  const content = createContent({
+    github_node_id: `I_${suffix}`,
+    github_url: `https://github.com/owner/repo/issues/${opts.number}`,
+    repo: repoRef,
+    number: opts.number,
+    title: opts.title,
+    body: "body",
+    state: "OPEN",
+    author: null,
+    deleted_at: null,
+    content_hash: `hash_${suffix}`,
+    embedding: opts.embedding,
+    embedded_content_hash: null,
+  });
   await db.query(
-    `CREATE issue CONTENT {
-      github_node_id: $gid,
-      github_url: $url,
-      repo: $repo,
-      number: $number,
-      title: $title,
-      body: 'body',
-      state: 'OPEN',
-      author: NONE,
-      created_at: time::now(),
-      updated_at: time::now(),
-      deleted_at: NONE,
-      content_hash: $hash,
-      embedding: ${embeddingExpr},
-      embedded_content_hash: NONE
-    }`,
-    {
-      gid: `I_${suffix}`,
-      url: `https://github.com/owner/repo/issues/${opts.number}`,
-      repo: repoRef,
-      number: opts.number,
-      title: opts.title,
-      hash: `hash_${suffix}`,
-      ...(opts.embedding !== null ? { embedding: opts.embedding } : {}),
-    },
+    `CREATE issue CONTENT ${content.sql.slice(0, -2)}, created_at: time::now(), updated_at: time::now() }`,
+    content.params,
   );
 }
 

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -1,6 +1,7 @@
 import { gh } from "../clients/github.ts";
 import { withDb } from "../clients/surreal.ts";
 import { StringRecordId } from "surrealdb";
+import { createContent, updateSet } from "../clients/surreal_helpers.ts";
 import { fetchLabelsCatalog, persistLabelCatalog } from "../ingest/labels.ts";
 import { fetchIssues, persistIssue } from "../ingest/issue.ts";
 import { fetchPullRequests, persistPullRequest } from "../ingest/pull_request.ts";
@@ -117,45 +118,33 @@ export default async function run(args: string[]): Promise<void> {
 
     let orgId: unknown;
     if (existingOrgs.length === 0) {
+      const orgContent = createContent({
+        github_node_id: ownerData.id,
+        github_url: ownerData.url,
+        login: ownerData.login,
+        name: ownerData.name,
+        kind: ownerData.__typename,
+        created_at: new Date(ownerData.createdAt),
+        updated_at: new Date(ownerData.updatedAt),
+        deleted_at: null,
+      });
       const [created] = await db.query<[Array<{ id: unknown }>]>(
-        `CREATE org CONTENT {
-          github_node_id: $github_node_id,
-          github_url: $github_url,
-          login: $login,
-          name: $name,
-          kind: $kind,
-          created_at: $created_at,
-          updated_at: $updated_at,
-          deleted_at: NONE
-        }`,
-        {
-          github_node_id: ownerData.id,
-          github_url: ownerData.url,
-          login: ownerData.login,
-          name: ownerData.name,
-          kind: ownerData.__typename,
-          created_at: new Date(ownerData.createdAt),
-          updated_at: new Date(ownerData.updatedAt),
-        },
+        `CREATE org CONTENT ${orgContent.sql}`,
+        orgContent.params,
       );
       orgId = created[0].id;
     } else {
       orgId = existingOrgs[0].id;
+      const orgSet = updateSet({
+        github_url: ownerData.url,
+        login: ownerData.login,
+        name: ownerData.name,
+        kind: ownerData.__typename,
+        updated_at: new Date(ownerData.updatedAt),
+      });
       await db.query(
-        `UPDATE $id SET
-          github_url = $github_url,
-          login = $login,
-          name = $name,
-          kind = $kind,
-          updated_at = $updated_at`,
-        {
-          id: orgId,
-          github_url: ownerData.url,
-          login: ownerData.login,
-          name: ownerData.name,
-          kind: ownerData.__typename,
-          updated_at: new Date(ownerData.updatedAt),
-        },
+        `UPDATE $id ${orgSet.sql}`,
+        { id: orgId, ...orgSet.params },
       );
     }
 
@@ -164,58 +153,36 @@ export default async function run(args: string[]): Promise<void> {
       { github_node_id: repository.id },
     );
 
-    const descSql = repository.description !== null ? "$description" : "NONE";
-    const descParam =
-      repository.description !== null ? { description: repository.description } : {};
-
     if (existingRepos.length === 0) {
+      const repoContent = createContent({
+        github_node_id: repository.id,
+        github_url: repository.url,
+        name,
+        name_with_owner: repository.nameWithOwner,
+        description: repository.description,
+        is_private: repository.isPrivate,
+        owner: orgId as object,
+        created_at: new Date(repository.createdAt),
+        updated_at: new Date(repository.updatedAt),
+      });
       await db.query(
-        `CREATE repo CONTENT {
-          github_node_id: $github_node_id,
-          github_url: $github_url,
-          name: $name,
-          name_with_owner: $name_with_owner,
-          description: ${descSql},
-          is_private: $is_private,
-          owner: $owner,
-          created_at: $created_at,
-          updated_at: $updated_at,
-          registered_at: time::now()
-        }`,
-        {
-          github_node_id: repository.id,
-          github_url: repository.url,
-          name,
-          name_with_owner: repository.nameWithOwner,
-          is_private: repository.isPrivate,
-          owner: orgId,
-          created_at: new Date(repository.createdAt),
-          updated_at: new Date(repository.updatedAt),
-          ...descParam,
-        },
+        `CREATE repo CONTENT ${repoContent.sql.slice(0, -2)}, registered_at: time::now() }`,
+        repoContent.params,
       );
     } else {
+      const repoSet = updateSet({
+        github_url: repository.url,
+        name,
+        name_with_owner: repository.nameWithOwner,
+        description: repository.description,
+        is_private: repository.isPrivate,
+        owner: orgId as object,
+        created_at: new Date(repository.createdAt),
+        updated_at: new Date(repository.updatedAt),
+      });
       await db.query(
-        `UPDATE $id SET
-          github_url = $github_url,
-          name = $name,
-          name_with_owner = $name_with_owner,
-          description = ${descSql},
-          is_private = $is_private,
-          owner = $owner,
-          created_at = $created_at,
-          updated_at = $updated_at`,
-        {
-          id: existingRepos[0].id,
-          github_url: repository.url,
-          name,
-          name_with_owner: repository.nameWithOwner,
-          is_private: repository.isPrivate,
-          owner: orgId,
-          created_at: new Date(repository.createdAt),
-          updated_at: new Date(repository.updatedAt),
-          ...descParam,
-        },
+        `UPDATE $id ${repoSet.sql}`,
+        { id: existingRepos[0].id, ...repoSet.params },
       );
     }
 

--- a/src/ingest/comment.ts
+++ b/src/ingest/comment.ts
@@ -5,6 +5,7 @@ import type { Surreal } from "surrealdb";
 import { paginate, gh } from "../clients/github.ts";
 import { isBot } from "./bot.ts";
 import { upsertUser } from "./user.ts";
+import { createContent, updateSet } from "../clients/surreal_helpers.ts";
 import type { ParsedUser } from "./types.ts";
 
 export type ParsedComment = {
@@ -352,72 +353,46 @@ export async function persistComment(db: Surreal, parsed: ParsedComment): Promis
     authorRef = new StringRecordId(id);
   }
 
-  const authorSql = parsed.author !== null ? "$author" : "NONE";
-  const parentIssueSql = parsed.parent_kind === "issue" ? "$parent_issue" : "NONE";
-  const parentPrSql = parsed.parent_kind === "pull_request" ? "$parent_pr" : "NONE";
-  const parentDiscussionSql = parsed.parent_kind === "discussion" ? "$parent_discussion" : "NONE";
-  const parentCommentSql = parsed.parent_comment_node_id !== null ? "$parent_comment" : "NONE";
-
   const [existing] = await db.query<[Array<{ id: unknown }>]>(
     "SELECT id FROM comment WHERE github_node_id = $github_node_id",
     { github_node_id: parsed.github_node_id },
   );
 
   if (existing.length === 0) {
+    const content = createContent({
+      github_node_id: parsed.github_node_id,
+      github_url: parsed.github_url,
+      parent_issue: parsed.parent_kind === "issue" ? parentRef : null,
+      parent_pr: parsed.parent_kind === "pull_request" ? parentRef : null,
+      parent_discussion: parsed.parent_kind === "discussion" ? parentRef : null,
+      parent_comment: parentCommentRef ?? null,
+      author: authorRef ?? null,
+      body: parsed.body,
+      created_at: parsed.created_at,
+      updated_at: parsed.updated_at,
+      deleted_at: null,
+      content_hash: parsed.content_hash,
+      embedding: null,
+    });
     await db.query(
-      `CREATE comment CONTENT {
-        github_node_id: $github_node_id,
-        github_url: $github_url,
-        parent_issue: ${parentIssueSql},
-        parent_pr: ${parentPrSql},
-        parent_discussion: ${parentDiscussionSql},
-        parent_comment: ${parentCommentSql},
-        author: ${authorSql},
-        body: $body,
-        created_at: $created_at,
-        updated_at: $updated_at,
-        deleted_at: NONE,
-        content_hash: $content_hash,
-        embedding: NONE
-      }`,
-      {
-        github_node_id: parsed.github_node_id,
-        github_url: parsed.github_url,
-        ...(parsed.parent_kind === "issue" ? { parent_issue: parentRef } : {}),
-        ...(parsed.parent_kind === "pull_request" ? { parent_pr: parentRef } : {}),
-        ...(parsed.parent_kind === "discussion" ? { parent_discussion: parentRef } : {}),
-        ...(parsed.parent_comment_node_id !== null ? { parent_comment: parentCommentRef } : {}),
-        ...(parsed.author !== null ? { author: authorRef } : {}),
-        body: parsed.body,
-        created_at: parsed.created_at,
-        updated_at: parsed.updated_at,
-        content_hash: parsed.content_hash,
-      },
+      `CREATE comment CONTENT ${content.sql}`,
+      content.params,
     );
   } else {
+    const set = updateSet({
+      github_url: parsed.github_url,
+      parent_issue: parsed.parent_kind === "issue" ? parentRef : null,
+      parent_pr: parsed.parent_kind === "pull_request" ? parentRef : null,
+      parent_discussion: parsed.parent_kind === "discussion" ? parentRef : null,
+      parent_comment: parentCommentRef ?? null,
+      author: authorRef ?? null,
+      body: parsed.body,
+      updated_at: parsed.updated_at,
+      content_hash: parsed.content_hash,
+    });
     await db.query(
-      `UPDATE $id SET
-        github_url = $github_url,
-        parent_issue = ${parentIssueSql},
-        parent_pr = ${parentPrSql},
-        parent_discussion = ${parentDiscussionSql},
-        parent_comment = ${parentCommentSql},
-        author = ${authorSql},
-        body = $body,
-        updated_at = $updated_at,
-        content_hash = $content_hash`,
-      {
-        id: new StringRecordId(String(existing[0].id)),
-        github_url: parsed.github_url,
-        ...(parsed.parent_kind === "issue" ? { parent_issue: parentRef } : {}),
-        ...(parsed.parent_kind === "pull_request" ? { parent_pr: parentRef } : {}),
-        ...(parsed.parent_kind === "discussion" ? { parent_discussion: parentRef } : {}),
-        ...(parsed.parent_comment_node_id !== null ? { parent_comment: parentCommentRef } : {}),
-        ...(parsed.author !== null ? { author: authorRef } : {}),
-        body: parsed.body,
-        updated_at: parsed.updated_at,
-        content_hash: parsed.content_hash,
-      },
+      `UPDATE $id ${set.sql}`,
+      { id: new StringRecordId(String(existing[0].id)), ...set.params },
     );
   }
 }

--- a/src/ingest/discussion.ts
+++ b/src/ingest/discussion.ts
@@ -6,6 +6,7 @@ import { paginate, gh } from "../clients/github.ts";
 import { isBot } from "./bot.ts";
 import { upsertUser } from "./user.ts";
 import { upsertLabelsAndEdges } from "./labels.ts";
+import { createContent, updateSet } from "../clients/surreal_helpers.ts";
 import type { ParsedUser, ParsedLabel, RepoRef } from "./types.ts";
 
 export type ParsedDiscussion = {
@@ -223,10 +224,6 @@ export async function persistDiscussion(
     authorRef = new StringRecordId(id);
   }
 
-  const authorSql = parsed.author !== null ? "$author" : "NONE";
-  const answerChosenAtSql = parsed.answer_chosen_at !== null ? "$answer_chosen_at" : "NONE";
-  const categorySql = parsed.category_name !== null ? "$category" : "NONE";
-
   const [existing] = await db.query<[Array<{ id: unknown }>]>(
     "SELECT id FROM discussion WHERE github_node_id = $github_node_id",
     { github_node_id: parsed.github_node_id },
@@ -235,62 +232,42 @@ export async function persistDiscussion(
   let discussionRecordId: string;
 
   if (existing.length === 0) {
+    const content = createContent({
+      github_node_id: parsed.github_node_id,
+      github_url: parsed.github_url,
+      repo: repoRef,
+      number: parsed.number,
+      title: parsed.title,
+      body: parsed.body,
+      category: parsed.category_name,
+      author: authorRef ?? null,
+      answer_chosen_at: parsed.answer_chosen_at,
+      created_at: parsed.created_at,
+      updated_at: parsed.updated_at,
+      deleted_at: null,
+      content_hash: parsed.content_hash,
+      embedding: null,
+    });
     const [created] = await db.query<[Array<{ id: unknown }>]>(
-      `CREATE discussion CONTENT {
-        github_node_id: $github_node_id,
-        github_url: $github_url,
-        repo: $repo,
-        number: $number,
-        title: $title,
-        body: $body,
-        category: ${categorySql},
-        author: ${authorSql},
-        answer_chosen_at: ${answerChosenAtSql},
-        created_at: $created_at,
-        updated_at: $updated_at,
-        deleted_at: NONE,
-        content_hash: $content_hash,
-        embedding: NONE
-      }`,
-      {
-        github_node_id: parsed.github_node_id,
-        github_url: parsed.github_url,
-        repo: repoRef,
-        number: parsed.number,
-        title: parsed.title,
-        body: parsed.body,
-        ...(parsed.category_name !== null ? { category: parsed.category_name } : {}),
-        ...(parsed.author !== null ? { author: authorRef } : {}),
-        ...(parsed.answer_chosen_at !== null ? { answer_chosen_at: parsed.answer_chosen_at } : {}),
-        created_at: parsed.created_at,
-        updated_at: parsed.updated_at,
-        content_hash: parsed.content_hash,
-      },
+      `CREATE discussion CONTENT ${content.sql}`,
+      content.params,
     );
     discussionRecordId = String(created[0].id);
   } else {
     discussionRecordId = String(existing[0].id);
+    const set = updateSet({
+      github_url: parsed.github_url,
+      title: parsed.title,
+      body: parsed.body,
+      category: parsed.category_name,
+      author: authorRef ?? null,
+      answer_chosen_at: parsed.answer_chosen_at,
+      updated_at: parsed.updated_at,
+      content_hash: parsed.content_hash,
+    });
     await db.query(
-      `UPDATE $id SET
-        github_url = $github_url,
-        title = $title,
-        body = $body,
-        category = ${categorySql},
-        author = ${authorSql},
-        answer_chosen_at = ${answerChosenAtSql},
-        updated_at = $updated_at,
-        content_hash = $content_hash`,
-      {
-        id: new StringRecordId(discussionRecordId),
-        github_url: parsed.github_url,
-        title: parsed.title,
-        body: parsed.body,
-        ...(parsed.category_name !== null ? { category: parsed.category_name } : {}),
-        ...(parsed.author !== null ? { author: authorRef } : {}),
-        ...(parsed.answer_chosen_at !== null ? { answer_chosen_at: parsed.answer_chosen_at } : {}),
-        updated_at: parsed.updated_at,
-        content_hash: parsed.content_hash,
-      },
+      `UPDATE $id ${set.sql}`,
+      { id: new StringRecordId(discussionRecordId), ...set.params },
     );
   }
 

--- a/src/ingest/issue.ts
+++ b/src/ingest/issue.ts
@@ -6,6 +6,7 @@ import { paginate, gh } from "../clients/github.ts";
 import { isBot } from "./bot.ts";
 import { upsertUser } from "./user.ts";
 import { upsertLabelsAndEdges } from "./labels.ts";
+import { createContent, updateSet } from "../clients/surreal_helpers.ts";
 import type { ParsedUser, ParsedLabel, RepoRef } from "./types.ts";
 
 export type ParsedIssue = {
@@ -196,10 +197,6 @@ export async function persistIssue(
     authorRef = new StringRecordId(id);
   }
 
-  const authorSql = parsed.author !== null ? "$author" : "NONE";
-  const stateReasonSql = parsed.state_reason !== null ? "$state_reason" : "NONE";
-  const closedAtSql = parsed.closed_at !== null ? "$closed_at" : "NONE";
-
   const [existing] = await db.query<[Array<{ id: unknown }>]>(
     "SELECT id FROM issue WHERE github_node_id = $github_node_id",
     { github_node_id: parsed.github_node_id },
@@ -208,66 +205,44 @@ export async function persistIssue(
   let issueRecordId: string;
 
   if (existing.length === 0) {
+    const content = createContent({
+      github_node_id: parsed.github_node_id,
+      github_url: parsed.github_url,
+      repo: repoRef,
+      number: parsed.number,
+      title: parsed.title,
+      body: parsed.body,
+      state: parsed.state,
+      state_reason: parsed.state_reason,
+      author: authorRef ?? null,
+      closed_at: parsed.closed_at,
+      created_at: parsed.created_at,
+      updated_at: parsed.updated_at,
+      deleted_at: null,
+      content_hash: parsed.content_hash,
+      embedding: null,
+    });
     const [created] = await db.query<[Array<{ id: unknown }>]>(
-      `CREATE issue CONTENT {
-        github_node_id: $github_node_id,
-        github_url: $github_url,
-        repo: $repo,
-        number: $number,
-        title: $title,
-        body: $body,
-        state: $state,
-        state_reason: ${stateReasonSql},
-        author: ${authorSql},
-        closed_at: ${closedAtSql},
-        created_at: $created_at,
-        updated_at: $updated_at,
-        deleted_at: NONE,
-        content_hash: $content_hash,
-        embedding: NONE
-      }`,
-      {
-        github_node_id: parsed.github_node_id,
-        github_url: parsed.github_url,
-        repo: repoRef,
-        number: parsed.number,
-        title: parsed.title,
-        body: parsed.body,
-        state: parsed.state,
-        ...(parsed.state_reason !== null ? { state_reason: parsed.state_reason } : {}),
-        ...(parsed.author !== null ? { author: authorRef } : {}),
-        ...(parsed.closed_at !== null ? { closed_at: parsed.closed_at } : {}),
-        created_at: parsed.created_at,
-        updated_at: parsed.updated_at,
-        content_hash: parsed.content_hash,
-      },
+      `CREATE issue CONTENT ${content.sql}`,
+      content.params,
     );
     issueRecordId = String(created[0].id);
   } else {
     issueRecordId = String(existing[0].id);
+    const set = updateSet({
+      github_url: parsed.github_url,
+      title: parsed.title,
+      body: parsed.body,
+      state: parsed.state,
+      state_reason: parsed.state_reason,
+      author: authorRef ?? null,
+      closed_at: parsed.closed_at,
+      updated_at: parsed.updated_at,
+      content_hash: parsed.content_hash,
+    });
     await db.query(
-      `UPDATE $id SET
-        github_url = $github_url,
-        title = $title,
-        body = $body,
-        state = $state,
-        state_reason = ${stateReasonSql},
-        author = ${authorSql},
-        closed_at = ${closedAtSql},
-        updated_at = $updated_at,
-        content_hash = $content_hash`,
-      {
-        id: new StringRecordId(issueRecordId),
-        github_url: parsed.github_url,
-        title: parsed.title,
-        body: parsed.body,
-        state: parsed.state,
-        ...(parsed.state_reason !== null ? { state_reason: parsed.state_reason } : {}),
-        ...(parsed.author !== null ? { author: authorRef } : {}),
-        ...(parsed.closed_at !== null ? { closed_at: parsed.closed_at } : {}),
-        updated_at: parsed.updated_at,
-        content_hash: parsed.content_hash,
-      },
+      `UPDATE $id ${set.sql}`,
+      { id: new StringRecordId(issueRecordId), ...set.params },
     );
   }
 

--- a/src/ingest/labels.ts
+++ b/src/ingest/labels.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { StringRecordId } from "surrealdb";
 import type { Surreal } from "surrealdb";
 import { paginate } from "../clients/github.ts";
+import { createContent, updateSet } from "../clients/surreal_helpers.ts";
 import type { ParsedLabel, RepoRef } from "./types.ts";
 
 const LabelNodeSchema = z.object({
@@ -57,8 +58,6 @@ export async function persistLabelCatalog(
   parsed: ParsedLabel,
 ): Promise<void> {
   const repoRef = new StringRecordId(repo.id);
-  const descSql = parsed.description === null ? "NONE" : "$description";
-  const descParam = parsed.description !== null ? { description: parsed.description } : {};
 
   const [existing] = await db.query<[Array<{ id: unknown }>]>(
     "SELECT id FROM label WHERE github_node_id = $github_node_id",
@@ -66,40 +65,28 @@ export async function persistLabelCatalog(
   );
 
   if (existing.length === 0) {
+    const content = createContent({
+      github_node_id: parsed.github_node_id,
+      repo: repoRef,
+      name: parsed.name,
+      color: parsed.color,
+      description: parsed.description,
+      deleted_at: null,
+    });
     await db.query(
-      `CREATE label CONTENT {
-        github_node_id: $github_node_id,
-        repo: $repo,
-        name: $name,
-        color: $color,
-        description: ${descSql},
-        created_at: time::now(),
-        updated_at: time::now(),
-        deleted_at: NONE
-      }`,
-      {
-        github_node_id: parsed.github_node_id,
-        repo: repoRef,
-        name: parsed.name,
-        color: parsed.color,
-        ...descParam,
-      },
+      `CREATE label CONTENT ${content.sql.slice(0, -2)}, created_at: time::now(), updated_at: time::now() }`,
+      content.params,
     );
   } else {
+    const set = updateSet({
+      name: parsed.name,
+      color: parsed.color,
+      description: parsed.description,
+      repo: repoRef,
+    });
     await db.query(
-      `UPDATE $id SET
-        name = $name,
-        color = $color,
-        description = ${descSql},
-        updated_at = time::now(),
-        repo = $repo`,
-      {
-        id: existing[0].id,
-        name: parsed.name,
-        color: parsed.color,
-        repo: repoRef,
-        ...descParam,
-      },
+      `UPDATE $id ${set.sql}, updated_at = time::now()`,
+      { id: existing[0].id, ...set.params },
     );
   }
 }
@@ -125,45 +112,31 @@ export async function upsertLabelsAndEdges(
       { github_node_id: label.github_node_id },
     );
 
-    const descSql = label.description === null ? "NONE" : "$description";
-    const descParam = label.description !== null ? { description: label.description } : {};
-
     let labelId: unknown;
     if (existing.length === 0) {
+      const content = createContent({
+        github_node_id: label.github_node_id,
+        repo: repoId as object,
+        name: label.name,
+        color: label.color,
+        description: label.description,
+        deleted_at: null,
+      });
       const [created] = await db.query<[Array<{ id: unknown }>]>(
-        `CREATE label CONTENT {
-          github_node_id: $github_node_id,
-          repo: $repo,
-          name: $name,
-          color: $color,
-          description: ${descSql},
-          created_at: time::now(),
-          updated_at: time::now(),
-          deleted_at: NONE
-        }`,
-        {
-          github_node_id: label.github_node_id,
-          repo: repoId,
-          name: label.name,
-          color: label.color,
-          ...descParam,
-        },
+        `CREATE label CONTENT ${content.sql.slice(0, -2)}, created_at: time::now(), updated_at: time::now() }`,
+        content.params,
       );
       labelId = created[0].id;
     } else {
       labelId = existing[0].id;
+      const set = updateSet({
+        name: label.name,
+        color: label.color,
+        description: label.description,
+      });
       await db.query(
-        `UPDATE $id SET
-          name = $name,
-          color = $color,
-          description = ${descSql},
-          updated_at = time::now()`,
-        {
-          id: labelId,
-          name: label.name,
-          color: label.color,
-          ...descParam,
-        },
+        `UPDATE $id ${set.sql}, updated_at = time::now()`,
+        { id: labelId, ...set.params },
       );
     }
     labelIds.push(labelId);

--- a/src/ingest/pull_request.ts
+++ b/src/ingest/pull_request.ts
@@ -7,6 +7,7 @@ import { computeContentHash } from "./issue.ts";
 import { upsertUser } from "./user.ts";
 import { upsertLabelsAndEdges } from "./labels.ts";
 import { linkClosingIssues } from "./crossrefs.ts";
+import { createContent, updateSet } from "../clients/surreal_helpers.ts";
 import type { ParsedUser, ParsedLabel, RepoRef } from "./types.ts";
 
 export type ParsedCommit = {
@@ -293,9 +294,6 @@ export async function persistPullRequest(
     const id = await upsertUser(db, parsed.author);
     authorRef = new StringRecordId(id);
   }
-  const authorSql = parsed.author !== null ? "$author" : "NONE";
-  const mergedAtSql = parsed.merged_at !== null ? "$merged_at" : "NONE";
-  const closedAtSql = parsed.closed_at !== null ? "$closed_at" : "NONE";
 
   // 2. Lookup PR by github_node_id; CREATE or UPDATE
   const [existing] = await db.query<[Array<{ id: unknown }>]>(
@@ -306,66 +304,44 @@ export async function persistPullRequest(
   let prRecordId: string;
 
   if (existing.length === 0) {
+    const content = createContent({
+      github_node_id: parsed.github_node_id,
+      github_url: parsed.github_url,
+      repo: repoRef,
+      number: parsed.number,
+      title: parsed.title,
+      body: parsed.body,
+      state: parsed.state,
+      author: authorRef ?? null,
+      merged_at: parsed.merged_at,
+      closed_at: parsed.closed_at,
+      created_at: parsed.created_at,
+      updated_at: parsed.updated_at,
+      deleted_at: null,
+      content_hash: parsed.content_hash,
+      embedding: null,
+    });
     const [created] = await db.query<[Array<{ id: unknown }>]>(
-      `CREATE pull_request CONTENT {
-        github_node_id: $github_node_id,
-        github_url: $github_url,
-        repo: $repo,
-        number: $number,
-        title: $title,
-        body: $body,
-        state: $state,
-        author: ${authorSql},
-        merged_at: ${mergedAtSql},
-        closed_at: ${closedAtSql},
-        created_at: $created_at,
-        updated_at: $updated_at,
-        deleted_at: NONE,
-        content_hash: $content_hash,
-        embedding: NONE
-      }`,
-      {
-        github_node_id: parsed.github_node_id,
-        github_url: parsed.github_url,
-        repo: repoRef,
-        number: parsed.number,
-        title: parsed.title,
-        body: parsed.body,
-        state: parsed.state,
-        ...(parsed.author !== null ? { author: authorRef } : {}),
-        ...(parsed.merged_at !== null ? { merged_at: parsed.merged_at } : {}),
-        ...(parsed.closed_at !== null ? { closed_at: parsed.closed_at } : {}),
-        created_at: parsed.created_at,
-        updated_at: parsed.updated_at,
-        content_hash: parsed.content_hash,
-      },
+      `CREATE pull_request CONTENT ${content.sql}`,
+      content.params,
     );
     prRecordId = String(created[0].id);
   } else {
     prRecordId = String(existing[0].id);
+    const set = updateSet({
+      github_url: parsed.github_url,
+      title: parsed.title,
+      body: parsed.body,
+      state: parsed.state,
+      author: authorRef ?? null,
+      merged_at: parsed.merged_at,
+      closed_at: parsed.closed_at,
+      updated_at: parsed.updated_at,
+      content_hash: parsed.content_hash,
+    });
     await db.query(
-      `UPDATE $id SET
-        github_url = $github_url,
-        title = $title,
-        body = $body,
-        state = $state,
-        author = ${authorSql},
-        merged_at = ${mergedAtSql},
-        closed_at = ${closedAtSql},
-        updated_at = $updated_at,
-        content_hash = $content_hash`,
-      {
-        id: new StringRecordId(prRecordId),
-        github_url: parsed.github_url,
-        title: parsed.title,
-        body: parsed.body,
-        state: parsed.state,
-        ...(parsed.author !== null ? { author: authorRef } : {}),
-        ...(parsed.merged_at !== null ? { merged_at: parsed.merged_at } : {}),
-        ...(parsed.closed_at !== null ? { closed_at: parsed.closed_at } : {}),
-        updated_at: parsed.updated_at,
-        content_hash: parsed.content_hash,
-      },
+      `UPDATE $id ${set.sql}`,
+      { id: new StringRecordId(prRecordId), ...set.params },
     );
   }
 
@@ -378,8 +354,6 @@ export async function persistPullRequest(
       const commitUserId = await upsertUser(db, commit.author);
       commitAuthorRef = new StringRecordId(commitUserId);
     }
-    const commitAuthorSql = commit.author !== null ? "$commit_author" : "NONE";
-    const messageBodySql = commit.message_body !== null ? "$message_body" : "NONE";
 
     const [existingCommit] = await db.query<[Array<{ id: unknown }>]>(
       "SELECT id FROM commit WHERE github_node_id = $github_node_id",
@@ -389,50 +363,34 @@ export async function persistPullRequest(
     let commitRecordId: string;
 
     if (existingCommit.length === 0) {
+      const commitContent = createContent({
+        github_node_id: commit.github_node_id,
+        github_url: commit.github_url,
+        repo: repoRef,
+        oid: commit.oid,
+        message_headline: commit.message_headline,
+        message_body: commit.message_body,
+        author: commitAuthorRef ?? null,
+        committed_date: commit.committed_date,
+        deleted_at: null,
+      });
       const [createdCommit] = await db.query<[Array<{ id: unknown }>]>(
-        `CREATE commit CONTENT {
-          github_node_id: $github_node_id,
-          github_url: $github_url,
-          repo: $repo,
-          oid: $oid,
-          message_headline: $message_headline,
-          message_body: ${messageBodySql},
-          author: ${commitAuthorSql},
-          committed_date: $committed_date,
-          created_at: time::now(),
-          updated_at: time::now(),
-          deleted_at: NONE
-        }`,
-        {
-          github_node_id: commit.github_node_id,
-          github_url: commit.github_url,
-          repo: repoRef,
-          oid: commit.oid,
-          message_headline: commit.message_headline,
-          ...(commit.message_body !== null ? { message_body: commit.message_body } : {}),
-          ...(commit.author !== null ? { commit_author: commitAuthorRef } : {}),
-          committed_date: commit.committed_date,
-        },
+        `CREATE commit CONTENT ${commitContent.sql.slice(0, -2)}, created_at: time::now(), updated_at: time::now() }`,
+        commitContent.params,
       );
       commitRecordId = String(createdCommit[0].id);
     } else {
       commitRecordId = String(existingCommit[0].id);
+      const commitSet = updateSet({
+        github_url: commit.github_url,
+        message_headline: commit.message_headline,
+        message_body: commit.message_body,
+        author: commitAuthorRef ?? null,
+        committed_date: commit.committed_date,
+      });
       await db.query(
-        `UPDATE $id SET
-          github_url = $github_url,
-          message_headline = $message_headline,
-          message_body = ${messageBodySql},
-          author = ${commitAuthorSql},
-          committed_date = $committed_date,
-          updated_at = time::now()`,
-        {
-          id: new StringRecordId(commitRecordId),
-          github_url: commit.github_url,
-          message_headline: commit.message_headline,
-          ...(commit.message_body !== null ? { message_body: commit.message_body } : {}),
-          ...(commit.author !== null ? { commit_author: commitAuthorRef } : {}),
-          committed_date: commit.committed_date,
-        },
+        `UPDATE $id ${commitSet.sql}, updated_at = time::now()`,
+        { id: new StringRecordId(commitRecordId), ...commitSet.params },
       );
     }
 

--- a/src/ingest/user.ts
+++ b/src/ingest/user.ts
@@ -1,4 +1,5 @@
 import type { Surreal } from "surrealdb";
+import { createContent, updateSet } from "../clients/surreal_helpers.ts";
 import type { ParsedUser } from "./types.ts";
 
 export async function upsertUser(db: Surreal, parsed: ParsedUser): Promise<string> {
@@ -8,39 +9,29 @@ export async function upsertUser(db: Surreal, parsed: ParsedUser): Promise<strin
   );
 
   if (existing.length > 0) {
+    const set = updateSet({
+      login: parsed.login,
+      is_bot: parsed.is_bot,
+      github_url: parsed.github_url,
+    });
     await db.query(
-      `UPDATE $id SET
-        login = $login,
-        is_bot = $is_bot,
-        github_url = $github_url,
-        updated_at = time::now()`,
-      {
-        id: existing[0].id,
-        login: parsed.login,
-        is_bot: parsed.is_bot,
-        github_url: parsed.github_url,
-      },
+      `UPDATE $id ${set.sql}, updated_at = time::now()`,
+      { id: existing[0].id, ...set.params },
     );
     return String(existing[0].id);
   }
 
+  const content = createContent({
+    github_node_id: parsed.github_node_id,
+    github_url: parsed.github_url,
+    login: parsed.login,
+    name: null,
+    is_bot: parsed.is_bot,
+    deleted_at: null,
+  });
   const [created] = await db.query<[Array<{ id: unknown }>]>(
-    `CREATE user CONTENT {
-      github_node_id: $github_node_id,
-      github_url: $github_url,
-      login: $login,
-      name: NONE,
-      is_bot: $is_bot,
-      created_at: time::now(),
-      updated_at: time::now(),
-      deleted_at: NONE
-    }`,
-    {
-      github_node_id: parsed.github_node_id,
-      github_url: parsed.github_url,
-      login: parsed.login,
-      is_bot: parsed.is_bot,
-    },
+    `CREATE user CONTENT ${content.sql.slice(0, -2)}, created_at: time::now(), updated_at: time::now() }`,
+    content.params,
   );
 
   return String(created[0].id);


### PR DESCRIPTION
## Summary

Extract `updateSet` and `createContent` helpers in `src/clients/surreal_helpers.ts` that compose SurrealQL `UPDATE ... SET ...` and `CREATE ... CONTENT { ... }` clauses from a JS object using **tri-state semantics**:

- concrete value → binds via `$fieldName` and appears in params
- `null` → inlines the SurrealQL literal `NONE`
- `undefined` → skips the field entirely

Refactor every inline-NONE template and conditional-spread pattern across the persister + commands surface onto the helpers. Net diff: **-93 lines** across 11 files.

## Changes

**New:**
- `src/clients/surreal_helpers.ts` — exports `updateSet`, `createContent`, types `FieldValue` and `FieldsResult`.
- `src/clients/surreal_helpers.test.ts` — 15 unit tests covering tri-state semantics, mixed inputs, empty inputs, snapshot of generated SQL.

**Refactored** (every `const xxxSql = value !== null ? '$xxx' : 'NONE'` and `...(value !== null ? { name: value } : {})` collapsed):
- `src/commands/add.ts` — repo metadata refresh.
- `src/commands/sync.ts` — repo metadata refresh.
- `src/ingest/issue.ts` — `persistIssue` CREATE + UPDATE.
- `src/ingest/pull_request.ts` — `persistPullRequest` for PR + commit.
- `src/ingest/discussion.ts` — `persistDiscussion`.
- `src/ingest/comment.ts` — `persistComment`.
- `src/ingest/labels.ts` — `persistLabelCatalog`, `upsertLabelsAndEdges`.
- `src/ingest/user.ts` — `upsertUser`.
- `src/commands/search.test.ts` — `seedIssue` test helper aligned with the new pattern (out-of-spec but trivial; kept for consistency).

## Test plan

- [x] `bun run typecheck` — clean.
- [x] `bun test` — 122 pass, 0 fail.
- [x] No new runtime dependencies (`git diff main -- package.json bun.lockb` empty).
- [x] Refactor is pure: query semantics unchanged, every site preserves its prior behavior (e.g. `authorRef ?? null` collapses the prior conditional spread).
- [ ] Manual smoke (live infra): `add lfnovo/esperanto && sync lfnovo/esperanto` produces identical row counts. **To be run after merge** (requires live SurrealDB + Ollama + token).

Closes #22


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted `updateSet` and `createContent` helpers to build SurrealQL SET/CONTENT clauses with tri‑state fields, and refactored all query sites to use them. This removes boilerplate while keeping behavior unchanged. Closes #22.

- **Refactors**
  - Added `src/clients/surreal_helpers.ts` (exports `updateSet`, `createContent`, and types) and `src/clients/surreal_helpers.test.ts` (unit tests).
  - Replaced inline NONE/conditional-spread patterns across `add`, `sync`, `issue`, `pull_request` (including commits), `discussion`, `comment`, `labels` (catalog/upsert), `user`, and `search.test`.
  - No new dependencies; typecheck and tests pass.

<sup>Written for commit 872fdd32b7d5def28d3f798f97e28fff9c6bb67c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

