### PR TITLE
feat(sync): incremental sync via updatedAt with --full flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist/
 *.log
 .DS_Store
 .harny/
+.claude/

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -3,7 +3,7 @@ export default function run(): void {
   console.log("");
   console.log("Commands:");
   console.log("  add      Register a GitHub repo for mirroring (tool add owner/name)");
-  console.log("  sync     Sync a registered repo (tool sync owner/name)");
+  console.log("  sync     Sync a registered repo (tool sync owner/name [--full])");
   console.log("  embed    Embed pending content for a synced repo (tool embed owner/name)");
   console.log("  list     List registered repos (tool list [--json])");
   console.log("  remove   Unregister a repo (tool remove owner/name [--purge] [--yes])");

--- a/src/commands/sync.test.ts
+++ b/src/commands/sync.test.ts
@@ -408,3 +408,79 @@ describe("sync command — --full flag", () => {
     testDb = null;
   });
 });
+
+describe("sync command — idempotency", () => {
+  it("two consecutive syncs produce no duplicate records and advance last_synced_at", async () => {
+    await withTestDb(async (db) => {
+      testDb = db;
+      ghCallCount = 0;
+
+      // Pre-seed org
+      const [orgRows] = await db.query<[Array<{ id: unknown }>]>(
+        `CREATE org CONTENT {
+          github_node_id: 'ORG_GH_ID',
+          github_url: 'https://github.com/lfnovo',
+          login: 'lfnovo',
+          name: 'Luis',
+          kind: 'User',
+          created_at: time::now(),
+          updated_at: time::now(),
+          deleted_at: NONE
+        }`,
+      );
+      const orgId = orgRows[0].id;
+
+      // Pre-seed repo WITHOUT last_synced_at so the first sync runs in full mode
+      await db.query(
+        `CREATE repo CONTENT {
+          github_node_id: 'REPO_GH_ID',
+          github_url: 'https://github.com/lfnovo/test-repo',
+          name: 'test-repo',
+          name_with_owner: 'lfnovo/test-repo',
+          description: NONE,
+          is_private: false,
+          owner: $owner,
+          created_at: time::now(),
+          updated_at: time::now(),
+          registered_at: time::now()
+        }`,
+        { owner: orgId },
+      );
+
+      // First sync — full mode (no last_synced_at)
+      await run(["lfnovo/test-repo"]);
+
+      const [[repoAfterFirst]] = await db.query<[[{ last_synced_at: unknown }]]>(
+        "SELECT last_synced_at FROM repo WHERE name_with_owner = $nwo",
+        { nwo: "lfnovo/test-repo" },
+      );
+      const ts1 = new Date(String(repoAfterFirst.last_synced_at));
+      expect(ts1.getTime()).toBeGreaterThan(0);
+
+      // Second sync — incremental mode (last_synced_at is now set to ts1)
+      await run(["lfnovo/test-repo"]);
+
+      const [[repoAfterSecond]] = await db.query<[[{ last_synced_at: unknown }]]>(
+        "SELECT last_synced_at FROM repo WHERE name_with_owner = $nwo",
+        { nwo: "lfnovo/test-repo" },
+      );
+      const ts2 = new Date(String(repoAfterSecond.last_synced_at));
+
+      // Issue count is still 1 — no duplicates created by the second run
+      const [[{ count: issueCount }]] = await db.query<[[{ count: number }]]>(
+        "SELECT count() FROM issue GROUP ALL",
+      );
+      expect(issueCount).toBe(1);
+
+      // Label count is still 1 — no duplicates created by the second run
+      const [[{ count: labelCount }]] = await db.query<[[{ count: number }]]>(
+        "SELECT count() FROM label GROUP ALL",
+      );
+      expect(labelCount).toBe(1);
+
+      // last_synced_at must have advanced on the second run
+      expect(ts2 > ts1).toBe(true);
+    });
+    testDb = null;
+  });
+});

--- a/src/commands/sync.test.ts
+++ b/src/commands/sync.test.ts
@@ -244,3 +244,59 @@ describe("sync command — repo not registered", () => {
     testDb = null;
   });
 });
+
+describe("sync command — incremental mode", () => {
+  it("logs incremental mode with timestamp and updates last_synced_at", async () => {
+    await withTestDb(async (db) => {
+      testDb = db;
+      ghCallCount = 0;
+
+      // Pre-seed org
+      const [orgRows] = await db.query<[Array<{ id: unknown }>]>(
+        `CREATE org CONTENT {
+          github_node_id: 'ORG_GH_ID',
+          github_url: 'https://github.com/lfnovo',
+          login: 'lfnovo',
+          name: 'Luis',
+          kind: 'User',
+          created_at: time::now(),
+          updated_at: time::now(),
+          deleted_at: NONE
+        }`,
+      );
+      const orgId = orgRows[0].id;
+
+      // Pre-seed repo with last_synced_at already set (simulating a second sync)
+      await db.query(
+        `CREATE repo CONTENT {
+          github_node_id: 'REPO_GH_ID',
+          github_url: 'https://github.com/lfnovo/test-repo',
+          name: 'test-repo',
+          name_with_owner: 'lfnovo/test-repo',
+          description: NONE,
+          is_private: false,
+          owner: $owner,
+          created_at: time::now(),
+          updated_at: time::now(),
+          registered_at: time::now(),
+          last_synced_at: $lastSyncedAt
+        }`,
+        { owner: orgId, lastSyncedAt: new Date('2024-06-01T00:00:00Z') },
+      );
+
+      const logs: string[] = [];
+      const origLog = console.log;
+      console.log = (...args: unknown[]) => { logs.push(args.map(String).join(' ')); };
+      try { await run(["lfnovo/test-repo"]); } finally { console.log = origLog; }
+
+      expect(logs.some(l => l.startsWith('Sync mode: incremental (since '))).toBe(true);
+
+      const [[repoRow]] = await db.query<[[{ last_synced_at: unknown }]]>(
+        "SELECT last_synced_at FROM repo WHERE name_with_owner = $nwo",
+        { nwo: "lfnovo/test-repo" },
+      );
+      expect(new Date(String(repoRow.last_synced_at)) > new Date('2024-06-01T00:00:00Z')).toBe(true);
+    });
+    testDb = null;
+  });
+});

--- a/src/commands/sync.test.ts
+++ b/src/commands/sync.test.ts
@@ -300,3 +300,111 @@ describe("sync command — incremental mode", () => {
     testDb = null;
   });
 });
+
+describe("sync command — --full flag", () => {
+  it("forces full mode even when last_synced_at is set (flag after repo arg)", async () => {
+    await withTestDb(async (db) => {
+      testDb = db;
+      ghCallCount = 0;
+
+      // Pre-seed org
+      const [orgRows] = await db.query<[Array<{ id: unknown }>]>(
+        `CREATE org CONTENT {
+          github_node_id: 'ORG_GH_ID',
+          github_url: 'https://github.com/lfnovo',
+          login: 'lfnovo',
+          name: 'Luis',
+          kind: 'User',
+          created_at: time::now(),
+          updated_at: time::now(),
+          deleted_at: NONE
+        }`,
+      );
+      const orgId = orgRows[0].id;
+
+      // Pre-seed repo with last_synced_at set — would normally trigger incremental mode
+      await db.query(
+        `CREATE repo CONTENT {
+          github_node_id: 'REPO_GH_ID',
+          github_url: 'https://github.com/lfnovo/test-repo',
+          name: 'test-repo',
+          name_with_owner: 'lfnovo/test-repo',
+          description: NONE,
+          is_private: false,
+          owner: $owner,
+          created_at: time::now(),
+          updated_at: time::now(),
+          registered_at: time::now(),
+          last_synced_at: $lastSyncedAt
+        }`,
+        { owner: orgId, lastSyncedAt: new Date('2024-06-01T00:00:00Z') },
+      );
+
+      const logs: string[] = [];
+      const origLog = console.log;
+      console.log = (...args: unknown[]) => { logs.push(args.map(String).join(' ')); };
+      try { await run(["lfnovo/test-repo", "--full"]); } finally { console.log = origLog; }
+
+      expect(logs.some(l => l === 'Sync mode: full')).toBe(true);
+
+      const [[{ count: issueCount }]] = await db.query<[[{ count: number }]]>(
+        "SELECT count() FROM issue GROUP ALL",
+      );
+      expect(issueCount).toBe(1);
+    });
+    testDb = null;
+  });
+
+  it("forces full mode when --full flag appears before the repo arg", async () => {
+    await withTestDb(async (db) => {
+      testDb = db;
+      ghCallCount = 0;
+
+      // Pre-seed org
+      const [orgRows] = await db.query<[Array<{ id: unknown }>]>(
+        `CREATE org CONTENT {
+          github_node_id: 'ORG_GH_ID',
+          github_url: 'https://github.com/lfnovo',
+          login: 'lfnovo',
+          name: 'Luis',
+          kind: 'User',
+          created_at: time::now(),
+          updated_at: time::now(),
+          deleted_at: NONE
+        }`,
+      );
+      const orgId = orgRows[0].id;
+
+      // Pre-seed repo with last_synced_at set
+      await db.query(
+        `CREATE repo CONTENT {
+          github_node_id: 'REPO_GH_ID',
+          github_url: 'https://github.com/lfnovo/test-repo',
+          name: 'test-repo',
+          name_with_owner: 'lfnovo/test-repo',
+          description: NONE,
+          is_private: false,
+          owner: $owner,
+          created_at: time::now(),
+          updated_at: time::now(),
+          registered_at: time::now(),
+          last_synced_at: $lastSyncedAt
+        }`,
+        { owner: orgId, lastSyncedAt: new Date('2024-06-01T00:00:00Z') },
+      );
+
+      const logs: string[] = [];
+      const origLog = console.log;
+      console.log = (...args: unknown[]) => { logs.push(args.map(String).join(' ')); };
+      try { await run(["--full", "lfnovo/test-repo"]); } finally { console.log = origLog; }
+
+      expect(logs.some(l => l === 'Sync mode: full')).toBe(true);
+
+      const [[{ count: issueCount }]] = await db.query<[[{ count: number }]]>(
+        "SELECT count() FROM issue GROUP ALL",
+      );
+      expect(issueCount).toBe(1);
+    });
+    testDb = null;
+  });
+});

--- a/src/commands/sync.test.ts
+++ b/src/commands/sync.test.ts
@@ -199,7 +199,12 @@ describe("sync command — happy path", () => {
         { owner: orgId },
       );
 
-      await run(["lfnovo/test-repo"]);
+      const logs: string[] = [];
+      const origLog = console.log;
+      console.log = (...args: unknown[]) => { logs.push(args.map(String).join(' ')); };
+      try { await run(["lfnovo/test-repo"]); } finally { console.log = origLog; }
+
+      expect(logs.some(l => l === 'Sync mode: full')).toBe(true);
 
       const [[repoRow]] = await db.query<[[{ last_synced_at: unknown }]]>(
         "SELECT last_synced_at FROM repo WHERE name_with_owner = $nwo",

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -82,7 +82,9 @@ function fmtTimestamp(d: Date): string {
 }
 
 export default async function run(args: string[]): Promise<void> {
-  const input = args[0];
+  const fullFlag = args.includes('--full');
+  const repoArg = args.find(a => !a.startsWith('--'));
+  const input = repoArg;
   if (!input || !/^[^/]+\/[^/]+$/.test(input)) {
     console.error("✗ Usage: tool sync <owner/name>");
     process.exit(1);
@@ -93,8 +95,8 @@ export default async function run(args: string[]): Promise<void> {
   await withDb(async (db) => {
     // 1. Load repo node
     const [repoRows] = await db.query<
-      [Array<{ id: unknown; name_with_owner: string; registered_at: unknown }>]
-    >("SELECT id, name_with_owner, registered_at FROM repo WHERE name_with_owner = $nwo", {
+      [Array<{ id: unknown; name_with_owner: string; registered_at: unknown; last_synced_at: unknown }>]
+    >("SELECT id, name_with_owner, registered_at, last_synced_at FROM repo WHERE name_with_owner = $nwo", {
       nwo: input,
     });
     const repoRow = repoRows[0];
@@ -105,6 +107,17 @@ export default async function run(args: string[]): Promise<void> {
       id: String(repoRow.id),
       name_with_owner: repoRow.name_with_owner,
     };
+
+    const mode: 'full' | 'incremental' =
+      fullFlag || repoRow.last_synced_at == null ? 'full' : 'incremental';
+    const since: Date | undefined =
+      mode === 'incremental' ? new Date(repoRow.last_synced_at as string) : undefined;
+
+    if (mode === 'incremental') {
+      console.log(`Sync mode: incremental (since ${since!.toISOString()})`);
+    } else {
+      console.log('Sync mode: full');
+    }
 
     // 2. Refresh metadata
     const data = await gh<{ repository: GitHubRepo }>(REPO_QUERY, { owner, name });
@@ -196,7 +209,7 @@ export default async function run(args: string[]): Promise<void> {
 
     // 4. Issues
     let issueCount = 0;
-    for await (const parsed of fetchIssues(owner, name)) {
+    for await (const parsed of fetchIssues(owner, name, since)) {
       await persistIssue(db, repoRef, parsed);
       issueCount++;
     }
@@ -205,7 +218,7 @@ export default async function run(args: string[]): Promise<void> {
     // 5. Pull requests
     let prCount = 0;
     let commitCount = 0;
-    for await (const parsed of fetchPullRequests(owner, name)) {
+    for await (const parsed of fetchPullRequests(owner, name, since)) {
       commitCount += parsed.commits.length;
       await persistPullRequest(db, repoRef, parsed);
       prCount++;
@@ -214,7 +227,7 @@ export default async function run(args: string[]): Promise<void> {
 
     // 6. Discussions
     let discussionCount = 0;
-    for await (const parsed of fetchDiscussions(owner, name)) {
+    for await (const parsed of fetchDiscussions(owner, name, since)) {
       await persistDiscussion(db, repoRef, parsed);
       discussionCount++;
     }
@@ -236,16 +249,17 @@ export default async function run(args: string[]): Promise<void> {
       const kindLabel =
         kind === "issue" ? "issues" : kind === "pull_request" ? "PRs" : "discussions";
 
+      const sinceFilter = since ? ' AND updated_at > $since' : '';
       const [parents] = await db.query<
         [Array<{ id: unknown; number: number; github_node_id: string }>]
       >(
-        `SELECT id, number, github_node_id FROM ${kind} WHERE repo = $repoRef AND deleted_at IS NONE`,
-        { repoRef: new StringRecordId(repoRef.id) },
+        `SELECT id, number, github_node_id FROM ${kind} WHERE repo = $repoRef AND deleted_at IS NONE${sinceFilter}`,
+        { repoRef: new StringRecordId(repoRef.id), ...(since ? { since } : {}) },
       );
 
       for (const parent of parents) {
         const remoteIds: string[] = [];
-        for await (const c of fetchFn(owner, name, parent.number)) {
+        for await (const c of fetchFn(owner, name, parent.number, since)) {
           await persistComment(db, c);
           remoteIds.push(c.github_node_id);
           commentCount++;

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -93,6 +93,10 @@ export default async function run(args: string[]): Promise<void> {
   const [owner, name] = input.split("/");
 
   await withDb(async (db) => {
+    // Captured at sync start so the watermark can never advance past
+    // updates that happened during this run; we'd miss them next time.
+    const syncStartedAt = new Date();
+
     // 1. Load repo node
     const [repoRows] = await db.query<
       [Array<{ id: unknown; name_with_owner: string; registered_at: unknown; last_synced_at: unknown }>]
@@ -294,11 +298,12 @@ export default async function run(args: string[]): Promise<void> {
     const { materialized: M } = await materializeDanglingReferences(db, repoRef);
     console.log(`✓ Dangling materialized: ${M}`);
 
-    // 11. Set last_synced_at
-    await db.query("UPDATE $id SET last_synced_at = time::now()", {
+    // 11. Set last_synced_at to the timestamp captured at sync start
+    await db.query("UPDATE $id SET last_synced_at = $syncStartedAt", {
       id: new StringRecordId(repoRef.id),
+      syncStartedAt,
     });
-    const ts = fmtTimestamp(new Date());
+    const ts = fmtTimestamp(syncStartedAt);
     console.log(`✓ Sync complete: ${repoRef.name_with_owner} @ ${ts}`);
   });
 }

--- a/src/ingest/comment.ts
+++ b/src/ingest/comment.ts
@@ -168,6 +168,7 @@ export async function* fetchCommentsForIssue(
   owner: string,
   name: string,
   issueNumber: number,
+  since?: Date,
 ): AsyncGenerator<ParsedComment> {
   let parentNodeId = "";
   for await (const rawNode of paginate(
@@ -209,6 +210,7 @@ export async function* fetchCommentsForPullRequest(
   owner: string,
   name: string,
   prNumber: number,
+  since?: Date,
 ): AsyncGenerator<ParsedComment> {
   let parentNodeId = "";
   for await (const rawNode of paginate(
@@ -250,6 +252,7 @@ export async function* fetchCommentsForDiscussion(
   owner: string,
   name: string,
   discussionNumber: number,
+  since?: Date,
 ): AsyncGenerator<ParsedComment> {
   let parentNodeId = "";
   for await (const rawNode of paginate(

--- a/src/ingest/discussion.test.ts
+++ b/src/ingest/discussion.test.ts
@@ -15,9 +15,11 @@ mock.module("../clients/github.ts", () => ({
       pageInfo: { hasNextPage: boolean; endCursor: string | null };
     },
   ) {
-    for (const page of [page1, page2]) {
+    // Pages reversed and nodes reversed to simulate the DESC ordering
+    // the production query requests (newest first across pages).
+    for (const page of [page2, page1]) {
       const connection = selectConnection(page);
-      for (const node of connection.nodes) {
+      for (const node of [...connection.nodes].reverse()) {
         yield node;
       }
     }
@@ -334,15 +336,16 @@ describe("fetchDiscussions — since filter", () => {
     expect(items.length).toBe(3);
   });
 
-  it("early-breaks after first item when since falls within fixture range", async () => {
+  it("yields newest-first and early-breaks before items at or older than since", async () => {
     ghProbeResult = { repository: { hasDiscussionsEnabled: true } };
     const items: ParsedDiscussion[] = [];
-    // D_001 updatedAt is 2026-01-02T00:00:00Z; since is noon that day → break fires after D_001
-    for await (const d of fetchDiscussions("test", "repo", new Date("2026-01-02T12:00:00Z"))) {
+    // Fixture (DESC): D_003 (Jan 5) → D_002 (Jan 3) → D_001 (Jan 2).
+    // since = Jan 4 cuts between D_003 and D_002 → expect [D_003] and the
+    // loop must terminate before yielding D_002.
+    for await (const d of fetchDiscussions("test", "repo", new Date("2026-01-04T00:00:00Z"))) {
       items.push(d);
     }
-    expect(items.length).toBe(1);
-    expect(items[0].github_node_id).toBe("D_001");
+    expect(items.map((d) => d.github_node_id)).toEqual(["D_003"]);
   });
 });
 

--- a/src/ingest/discussion.test.ts
+++ b/src/ingest/discussion.test.ts
@@ -321,6 +321,31 @@ describe("fetchDiscussions mock", () => {
   });
 });
 
+// ─── 7. fetchDiscussions — since filter ──────────────────────────────────────
+
+describe("fetchDiscussions — since filter", () => {
+  it("yields all items when since predates all fixture items", async () => {
+    ghProbeResult = { repository: { hasDiscussionsEnabled: true } };
+    const items: ParsedDiscussion[] = [];
+    for await (const d of fetchDiscussions("test", "repo", new Date("2020-01-01"))) {
+      items.push(d);
+    }
+    // All fixture items have updatedAt in 2026; none trigger early-break
+    expect(items.length).toBe(3);
+  });
+
+  it("early-breaks after first item when since falls within fixture range", async () => {
+    ghProbeResult = { repository: { hasDiscussionsEnabled: true } };
+    const items: ParsedDiscussion[] = [];
+    // D_001 updatedAt is 2026-01-02T00:00:00Z; since is noon that day → break fires after D_001
+    for await (const d of fetchDiscussions("test", "repo", new Date("2026-01-02T12:00:00Z"))) {
+      items.push(d);
+    }
+    expect(items.length).toBe(1);
+    expect(items[0].github_node_id).toBe("D_001");
+  });
+});
+
 // ─── 7. fetchDiscussions hasDiscussionsEnabled=false ─────────────────────────
 
 describe("fetchDiscussions hasDiscussionsEnabled=false", () => {

--- a/src/ingest/discussion.ts
+++ b/src/ingest/discussion.ts
@@ -194,6 +194,7 @@ export async function* fetchDiscussions(
 
     const content_hash = computeContentHash(node.title, node.body);
 
+    if (since && new Date(node.updatedAt) <= since) break;
     yield {
       github_node_id: node.id,
       github_url: node.url,
@@ -209,7 +210,6 @@ export async function* fetchDiscussions(
       author,
       labels,
     };
-    if (since && new Date(node.updatedAt) < since) break;
   }
 }
 

--- a/src/ingest/discussion.ts
+++ b/src/ingest/discussion.ts
@@ -153,6 +153,7 @@ export async function* fetchDiscussions(
     },
   )) {
     const node = DiscussionNodeSchema.parse(rawNode);
+    if (since && new Date(node.updatedAt) <= since) break;
 
     let author: ParsedUser | null = null;
     if (node.author !== null) {
@@ -194,7 +195,6 @@ export async function* fetchDiscussions(
 
     const content_hash = computeContentHash(node.title, node.body);
 
-    if (since && new Date(node.updatedAt) <= since) break;
     yield {
       github_node_id: node.id,
       github_url: node.url,

--- a/src/ingest/discussion.ts
+++ b/src/ingest/discussion.ts
@@ -82,7 +82,7 @@ const DISCUSSIONS_PROBE_QUERY = `
 const DISCUSSIONS_QUERY = `
   query FetchDiscussions($owner: String!, $name: String!, $cursor: String) {
     repository(owner: $owner, name: $name) {
-      discussions(first: 50, after: $cursor, orderBy: {field: UPDATED_AT, direction: ASC}) {
+      discussions(first: 50, after: $cursor, orderBy: {field: UPDATED_AT, direction: DESC}) {
         pageInfo { hasNextPage endCursor }
         nodes {
           id url number title body closedAt createdAt updatedAt
@@ -129,6 +129,7 @@ export function computeContentHash(title: string, rawBody: string | null): strin
 export async function* fetchDiscussions(
   owner: string,
   name: string,
+  since?: Date,
 ): AsyncGenerator<ParsedDiscussion> {
   const probeData = await gh<{ repository: { hasDiscussionsEnabled: boolean } }>(
     DISCUSSIONS_PROBE_QUERY,
@@ -208,6 +209,7 @@ export async function* fetchDiscussions(
       author,
       labels,
     };
+    if (since && new Date(node.updatedAt) < since) break;
   }
 }
 

--- a/src/ingest/issue.test.ts
+++ b/src/ingest/issue.test.ts
@@ -13,9 +13,11 @@ mock.module("../clients/github.ts", () => ({
       pageInfo: { hasNextPage: boolean; endCursor: string | null };
     },
   ) {
-    for (const page of [page1, page2]) {
+    // Pages reversed and nodes reversed to simulate the DESC ordering
+    // the production query requests (newest first across pages).
+    for (const page of [page2, page1]) {
       const connection = selectConnection(page);
-      for (const node of connection.nodes) {
+      for (const node of [...connection.nodes].reverse()) {
         yield node;
       }
     }
@@ -251,13 +253,14 @@ describe("fetchIssues — since filter", () => {
     expect(items.length).toBe(3);
   });
 
-  it("early-breaks after first item when since falls within fixture range", async () => {
+  it("yields newest-first and early-breaks before items at or older than since", async () => {
     const items: ParsedIssue[] = [];
-    // I_001 updatedAt is 2026-01-02T00:00:00Z; since is noon that day → break fires after I_001
-    for await (const issue of fetchIssues("test", "repo", new Date("2026-01-02T12:00:00Z"))) {
+    // Fixture (DESC): I_003 (Jan 5) → I_002 (Jan 3) → I_001 (Jan 2).
+    // since = Jan 4 cuts between I_003 and I_002 → expect [I_003] and the
+    // loop must terminate before yielding I_002.
+    for await (const issue of fetchIssues("test", "repo", new Date("2026-01-04T00:00:00Z"))) {
       items.push(issue);
     }
-    expect(items.length).toBe(1);
-    expect(items[0].github_node_id).toBe("I_001");
+    expect(items.map((i) => i.github_node_id)).toEqual(["I_003"]);
   });
 });

--- a/src/ingest/issue.test.ts
+++ b/src/ingest/issue.test.ts
@@ -238,3 +238,26 @@ describe("fetchIssues mock", () => {
     expect(issue1.body).toContain("\n");
   });
 });
+
+// ─── 5. fetchIssues — since filter ───────────────────────────────────────────
+
+describe("fetchIssues — since filter", () => {
+  it("yields all items when since predates all fixture items", async () => {
+    const items: ParsedIssue[] = [];
+    for await (const issue of fetchIssues("test", "repo", new Date("2020-01-01"))) {
+      items.push(issue);
+    }
+    // All fixture items have updatedAt in 2026; none trigger early-break
+    expect(items.length).toBe(3);
+  });
+
+  it("early-breaks after first item when since falls within fixture range", async () => {
+    const items: ParsedIssue[] = [];
+    // I_001 updatedAt is 2026-01-02T00:00:00Z; since is noon that day → break fires after I_001
+    for await (const issue of fetchIssues("test", "repo", new Date("2026-01-02T12:00:00Z"))) {
+      items.push(issue);
+    }
+    expect(items.length).toBe(1);
+    expect(items[0].github_node_id).toBe("I_001");
+  });
+});

--- a/src/ingest/issue.ts
+++ b/src/ingest/issue.ts
@@ -125,6 +125,7 @@ export async function* fetchIssues(owner: string, name: string, since?: Date): A
     },
   )) {
     const node = IssueNodeSchema.parse(rawNode);
+    if (since && new Date(node.updatedAt) <= since) break;
 
     let author: ParsedUser | null = null;
     if (node.author !== null) {
@@ -166,7 +167,6 @@ export async function* fetchIssues(owner: string, name: string, since?: Date): A
 
     const content_hash = computeContentHash(node.title, node.body);
 
-    if (since && new Date(node.updatedAt) <= since) break;
     yield {
       github_node_id: node.id,
       github_url: node.url,

--- a/src/ingest/issue.ts
+++ b/src/ingest/issue.ts
@@ -67,7 +67,7 @@ const IssueNodeSchema = z.object({
 const ISSUES_QUERY = `
   query FetchIssues($owner: String!, $name: String!, $cursor: String) {
     repository(owner: $owner, name: $name) {
-      issues(first: 100, after: $cursor, orderBy: {field: UPDATED_AT, direction: ASC}) {
+      issues(first: 100, after: $cursor, orderBy: {field: UPDATED_AT, direction: DESC}) {
         pageInfo { hasNextPage endCursor }
         nodes {
           id url number title body state stateReason closedAt createdAt updatedAt
@@ -108,7 +108,7 @@ export function computeContentHash(title: string, rawBody: string | null): strin
     .digest("hex");
 }
 
-export async function* fetchIssues(owner: string, name: string): AsyncGenerator<ParsedIssue> {
+export async function* fetchIssues(owner: string, name: string, since?: Date): AsyncGenerator<ParsedIssue> {
   for await (const rawNode of paginate(
     ISSUES_QUERY,
     { owner, name },
@@ -181,6 +181,7 @@ export async function* fetchIssues(owner: string, name: string): AsyncGenerator<
       author,
       labels,
     };
+    if (since && new Date(node.updatedAt) < since) break;
   }
 }
 

--- a/src/ingest/issue.ts
+++ b/src/ingest/issue.ts
@@ -166,6 +166,7 @@ export async function* fetchIssues(owner: string, name: string, since?: Date): A
 
     const content_hash = computeContentHash(node.title, node.body);
 
+    if (since && new Date(node.updatedAt) <= since) break;
     yield {
       github_node_id: node.id,
       github_url: node.url,
@@ -181,7 +182,6 @@ export async function* fetchIssues(owner: string, name: string, since?: Date): A
       author,
       labels,
     };
-    if (since && new Date(node.updatedAt) < since) break;
   }
 }
 

--- a/src/ingest/pull_request.test.ts
+++ b/src/ingest/pull_request.test.ts
@@ -302,6 +302,29 @@ describe("persistPullRequest MERGED state", () => {
   });
 });
 
+// ─── 7. fetchPullRequests — since filter ─────────────────────────────────────
+
+describe("fetchPullRequests — since filter", () => {
+  it("yields all items when since predates all fixture items", async () => {
+    const items: ParsedPullRequest[] = [];
+    for await (const pr of fetchPullRequests("test", "repo", new Date("2020-01-01"))) {
+      items.push(pr);
+    }
+    // All fixture items have updatedAt in 2026; none trigger early-break
+    expect(items.length).toBe(3);
+  });
+
+  it("early-breaks after first item when since falls within fixture range", async () => {
+    const items: ParsedPullRequest[] = [];
+    // PR_001 updatedAt is 2026-01-02T00:00:00Z; since is noon that day → break fires after PR_001
+    for await (const pr of fetchPullRequests("test", "repo", new Date("2026-01-02T12:00:00Z"))) {
+      items.push(pr);
+    }
+    expect(items.length).toBe(1);
+    expect(items[0].github_node_id).toBe("PR_001");
+  });
+});
+
 // ─── 7. persistPullRequest ghost commit author ────────────────────────────────
 
 describe("persistPullRequest ghost commit author", () => {

--- a/src/ingest/pull_request.test.ts
+++ b/src/ingest/pull_request.test.ts
@@ -13,9 +13,11 @@ mock.module("../clients/github.ts", () => ({
       pageInfo: { hasNextPage: boolean; endCursor: string | null };
     },
   ) {
-    for (const page of [page1, page2]) {
+    // Pages reversed and nodes reversed to simulate the DESC ordering
+    // the production query requests (newest first across pages).
+    for (const page of [page2, page1]) {
       const connection = selectConnection(page);
-      for (const node of connection.nodes) {
+      for (const node of [...connection.nodes].reverse()) {
         yield node;
       }
     }
@@ -314,14 +316,15 @@ describe("fetchPullRequests — since filter", () => {
     expect(items.length).toBe(3);
   });
 
-  it("early-breaks after first item when since falls within fixture range", async () => {
+  it("yields newest-first and early-breaks before items at or older than since", async () => {
     const items: ParsedPullRequest[] = [];
-    // PR_001 updatedAt is 2026-01-02T00:00:00Z; since is noon that day → break fires after PR_001
-    for await (const pr of fetchPullRequests("test", "repo", new Date("2026-01-02T12:00:00Z"))) {
+    // Fixture (DESC): PR_003 (Jan 10) → PR_002 (Jan 5) → PR_001 (Jan 2).
+    // since = Jan 4 cuts between PR_002 and PR_001 → expect [PR_003, PR_002]
+    // and the loop must terminate before yielding PR_001.
+    for await (const pr of fetchPullRequests("test", "repo", new Date("2026-01-04T00:00:00Z"))) {
       items.push(pr);
     }
-    expect(items.length).toBe(1);
-    expect(items[0].github_node_id).toBe("PR_001");
+    expect(items.map((p) => p.github_node_id)).toEqual(["PR_003", "PR_002"]);
   });
 });
 

--- a/src/ingest/pull_request.ts
+++ b/src/ingest/pull_request.ts
@@ -262,6 +262,7 @@ export async function* fetchPullRequests(
 
     const content_hash = computeContentHash(node.title, node.body);
 
+    if (since && new Date(node.updatedAt) <= since) break;
     yield {
       github_node_id: node.id,
       github_url: node.url,
@@ -279,7 +280,6 @@ export async function* fetchPullRequests(
       commits,
       closing_issue_node_ids,
     };
-    if (since && new Date(node.updatedAt) < since) break;
   }
 }
 

--- a/src/ingest/pull_request.ts
+++ b/src/ingest/pull_request.ts
@@ -196,6 +196,7 @@ export async function* fetchPullRequests(
     },
   )) {
     const node = PullRequestNodeSchema.parse(rawNode);
+    if (since && new Date(node.updatedAt) <= since) break;
 
     let author: ParsedUser | null = null;
     if (node.author !== null) {
@@ -262,7 +263,6 @@ export async function* fetchPullRequests(
 
     const content_hash = computeContentHash(node.title, node.body);
 
-    if (since && new Date(node.updatedAt) <= since) break;
     yield {
       github_node_id: node.id,
       github_url: node.url,

--- a/src/ingest/pull_request.ts
+++ b/src/ingest/pull_request.ts
@@ -117,7 +117,7 @@ const PULL_REQUESTS_QUERY = `
     repository(owner: $owner, name: $name) {
       pullRequests(
         states: [OPEN, CLOSED, MERGED],
-        orderBy: { field: UPDATED_AT, direction: ASC },
+        orderBy: { field: UPDATED_AT, direction: DESC },
         first: 50,
         after: $cursor
       ) {
@@ -178,6 +178,7 @@ const PR_COMMITS_QUERY = `
 export async function* fetchPullRequests(
   owner: string,
   name: string,
+  since?: Date,
 ): AsyncGenerator<ParsedPullRequest> {
   for await (const rawNode of paginate(
     PULL_REQUESTS_QUERY,
@@ -278,6 +279,7 @@ export async function* fetchPullRequests(
       commits,
       closing_issue_node_ids,
     };
+    if (since && new Date(node.updatedAt) < since) break;
   }
 }
 


### PR DESCRIPTION
## Summary

Make `tool sync` incremental by default once a repo has been synced once. Subsequent syncs filter by `updatedAt > last_synced_at` per kind, paginate newest-first (DESC), and break early when an item predates `since`. `--full` flag forces a complete re-walk.

Tombstone detection of items deleted upstream is **out of scope** (issue #15).

## Changes

**Fetchers** (`issue.ts`, `pull_request.ts`, `discussion.ts`) — accept optional `since?: Date`; switch GraphQL `orderBy` from `UPDATED_AT ASC` to `UPDATED_AT DESC`; break the generator after yielding the first item with `updatedAt < since`. Comment fetchers accept `since` for signature symmetry but the orchestrator filters parents via SQL.

**Sync orchestrator** (`commands/sync.ts`):
- Reads `repo.last_synced_at`. Mode = `full` if `--full` flag set or `last_synced_at` is none, else `incremental`.
- Logs `Sync mode: full` or `Sync mode: incremental (since <ISO>)`.
- Passes `since` to issue/PR/discussion fetchers.
- Comments: query parents with `AND updated_at > $since` so only changed parents trigger comment re-fetch.
- Labels: always full (cheap, no `since` filter).

**Help** — adds `--full` flag documentation.

**Tests** — `+253` lines:
- Fetcher tests cover since-filter early-break (issue, PR, discussion).
- Sync tests cover: full-mode log when no `last_synced_at`, incremental-mode log + `last_synced_at` update, `--full` override, idempotency of consecutive incremental syncs.

## Test plan

- [x] `bun run typecheck` — clean.
- [x] `bun test` — all pass (validator confirmed).
- [x] No new dependencies.
- [ ] Manual smoke (live infra): `tool sync lfnovo/esperanto` once (full); re-run (incremental, breaks early per kind, no row count change). **To be run after merge**.

## Out of scope

- Tombstone / soft-delete (issue #15).
- Comment edits without parent bump (accepted limitation, documented in design).
- Per-kind `last_synced_at` (single repo timestamp, design call).

Closes #14

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds incremental sync using updatedAt with a `--full` override, and moves the cutoff earlier to stop before stale items without extra API calls. Sets the sync watermark at run start to avoid missing in-flight updates. Closes #14.

- **New Features**
  - Detects mode from repo.last_synced_at or `--full`; logs “Sync mode” before any API calls.
  - Issues/PRs/Discussions: order by UPDATED_AT DESC; accept `since` and stop before items at or older than `since`.
  - Comments: only re-fetch for parents with `updated_at > since`; pass `since` to comment fetchers; labels always full.
  - Help updated: `tool sync owner/name [--full]`.

- **Bug Fixes**
  - Persist `last_synced_at` using the sync start timestamp, not completion time.
  - Robust arg parsing: repo arg is detected even if `--full` appears before it.
  - Apply `since` cutoff before label/commit pagination to avoid unnecessary GraphQL calls during incremental sync.

<sup>Written for commit 58f5b85c412519d07671e072fed3e1b4830064df. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

