### PR TITLE
feat(sync): --reconcile flag for top-level deletion reconciliation

### DIFF
--- a/schemas.surrealql
+++ b/schemas.surrealql
@@ -35,8 +35,9 @@ DEFINE FIELD IF NOT EXISTS description     ON TABLE repo TYPE option<string>;
 DEFINE FIELD IF NOT EXISTS is_private      ON TABLE repo TYPE bool DEFAULT false;
 -- Registration is the CLI's source of truth: a repo is "mirrored" iff registered_at is set.
 DEFINE FIELD IF NOT EXISTS registered_at   ON TABLE repo TYPE option<datetime>;
-DEFINE FIELD IF NOT EXISTS last_synced_at  ON TABLE repo TYPE option<datetime>;
-DEFINE FIELD IF NOT EXISTS created_at      ON TABLE repo TYPE datetime;
+DEFINE FIELD IF NOT EXISTS last_synced_at      ON TABLE repo TYPE option<datetime>;
+DEFINE FIELD IF NOT EXISTS last_reconciled_at  ON TABLE repo TYPE option<datetime>;
+DEFINE FIELD IF NOT EXISTS created_at          ON TABLE repo TYPE datetime;
 DEFINE FIELD IF NOT EXISTS updated_at      ON TABLE repo TYPE datetime;
 DEFINE FIELD IF NOT EXISTS deleted_at      ON TABLE repo TYPE option<datetime>;
 

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -3,7 +3,7 @@ export default function run(): void {
   console.log("");
   console.log("Commands:");
   console.log("  add      Register a GitHub repo for mirroring (tool add owner/name)");
-  console.log("  sync     Sync a registered repo (tool sync owner/name [--full])");
+  console.log("  sync     Sync a registered repo (tool sync owner/name [--full] [--reconcile])");
   console.log("  embed    Embed pending content for a synced repo (tool embed owner/name)");
   console.log("  list     List registered repos (tool list [--json])");
   console.log("  remove   Unregister a repo (tool remove owner/name [--purge] [--yes])");

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -18,6 +18,7 @@ import {
   tombstoneMissingComments,
 } from "../ingest/comment.ts";
 import { extractAndLinkCrossRefs, materializeDanglingReferences } from "../ingest/crossrefs.ts";
+import { reconcileTopLevel } from "../ingest/reconcile.ts";
 import type { RepoRef } from "../ingest/types.ts";
 
 type GitHubOwner = {
@@ -83,6 +84,7 @@ function fmtTimestamp(d: Date): string {
 
 export default async function run(args: string[]): Promise<void> {
   const fullFlag = args.includes('--full');
+  const reconcileFlag = args.includes('--reconcile');
   const repoArg = args.find(a => !a.startsWith('--'));
   const input = repoArg;
   if (!input || !/^[^/]+\/[^/]+$/.test(input)) {
@@ -298,7 +300,20 @@ export default async function run(args: string[]): Promise<void> {
     const { materialized: M } = await materializeDanglingReferences(db, repoRef);
     console.log(`✓ Dangling materialized: ${M}`);
 
-    // 11. Set last_synced_at to the timestamp captured at sync start
+    // 11. Reconcile top-level items against GitHub (optional)
+    if (reconcileFlag) {
+      try {
+        await reconcileTopLevel(db, repoRef, owner, name, gh);
+        await db.query("UPDATE $id SET last_reconciled_at = time::now()", {
+          id: new StringRecordId(repoRef.id),
+        });
+      } catch (err) {
+        console.error(`✗ Reconciliation failed: ${err}`);
+        process.exit(1);
+      }
+    }
+
+    // 12. Set last_synced_at to the timestamp captured at sync start
     await db.query("UPDATE $id SET last_synced_at = $syncStartedAt", {
       id: new StringRecordId(repoRef.id),
       syncStartedAt,

--- a/src/ingest/reconcile.test.ts
+++ b/src/ingest/reconcile.test.ts
@@ -322,4 +322,47 @@ describe("reconcileTopLevel — passive cascade", () => {
       expect(c1[0].is_none).toBe(true);
     });
   });
+
+  describe("discussions error handling", () => {
+    it("silently skips when GitHub reports discussions are not enabled", async () => {
+      await withTestDb(async (db) => {
+        const repoId = await setupRepo(db, "DiscDis");
+        const repo = { id: repoId, name_with_owner: "orgDiscDis/repo" };
+        await setupDiscussion(db, repoId, "D_LOCAL", 1);
+
+        const mockGh: GhFn = async <T>(query: string): Promise<T> => {
+          if (query.includes("FetchIssueIds") || query.includes("FetchPrIds")) {
+            return { repository: { [query.includes("FetchIssueIds") ? "issues" : "pullRequests"]: { pageInfo: { hasNextPage: false, endCursor: null }, nodes: [] } } } as T;
+          }
+          if (query.includes("FetchDiscussionIds")) {
+            throw new Error("Discussions are not enabled for this repository");
+          }
+          throw new Error("Unexpected query");
+        };
+
+        const result = await reconcileTopLevel(db, repo, "orgDiscDis", "repo", mockGh);
+        // Discussion not tombstoned because the path was skipped, not run.
+        expect(result.discussions_tombstoned).toBe(0);
+      });
+    });
+
+    it("propagates unrelated errors that happen to contain 'disabled'", async () => {
+      await withTestDb(async (db) => {
+        const repoId = await setupRepo(db, "DiscErr");
+        const repo = { id: repoId, name_with_owner: "orgDiscErr/repo" };
+
+        const mockGh: GhFn = async <T>(query: string): Promise<T> => {
+          if (query.includes("FetchIssueIds") || query.includes("FetchPrIds")) {
+            return { repository: { [query.includes("FetchIssueIds") ? "issues" : "pullRequests"]: { pageInfo: { hasNextPage: false, endCursor: null }, nodes: [] } } } as T;
+          }
+          // No mention of "discussion"; must NOT be silently swallowed.
+          throw new Error("Token disabled by admin");
+        };
+
+        await expect(
+          reconcileTopLevel(db, repo, "orgDiscErr", "repo", mockGh),
+        ).rejects.toThrow(/Token disabled by admin/);
+      });
+    });
+  });
 });

--- a/src/ingest/reconcile.test.ts
+++ b/src/ingest/reconcile.test.ts
@@ -1,0 +1,325 @@
+import { describe, it, expect } from "bun:test";
+import { StringRecordId } from "surrealdb";
+import { withTestDb } from "../test_utils/with_test_db.ts";
+import { reconcileTopLevel } from "./reconcile.ts";
+
+// ─── mock gh factory ─────────────────────────────────────────────────────────
+
+type GhFn = <T>(query: string, params?: Record<string, unknown>) => Promise<T>;
+
+function makeMockGh(issueIds: string[], prIds: string[], discIds: string[]): GhFn {
+  return async <T>(query: string, _params?: Record<string, unknown>): Promise<T> => {
+    if (query.includes("FetchIssueIds")) {
+      return {
+        repository: {
+          issues: {
+            pageInfo: { hasNextPage: false, endCursor: null },
+            nodes: issueIds.map((id) => ({ id })),
+          },
+        },
+      } as T;
+    }
+    if (query.includes("FetchPrIds")) {
+      return {
+        repository: {
+          pullRequests: {
+            pageInfo: { hasNextPage: false, endCursor: null },
+            nodes: prIds.map((id) => ({ id })),
+          },
+        },
+      } as T;
+    }
+    if (query.includes("FetchDiscussionIds")) {
+      return {
+        repository: {
+          discussions: {
+            pageInfo: { hasNextPage: false, endCursor: null },
+            nodes: discIds.map((id) => ({ id })),
+          },
+        },
+      } as T;
+    }
+    throw new Error(`Unexpected query in mock: ${query.slice(0, 60)}`);
+  };
+}
+
+// ─── DB seed helpers ──────────────────────────────────────────────────────────
+
+type Db = Parameters<Parameters<typeof withTestDb>[0]>[0];
+
+async function setupRepo(db: Db, suffix: string): Promise<string> {
+  const [orgRows] = await db.query<[Array<{ id: unknown }>]>(
+    `CREATE org CONTENT {
+      github_node_id: $nid,
+      github_url: $url,
+      login: $login,
+      name: $name,
+      kind: "User",
+      created_at: time::now(),
+      updated_at: time::now(),
+      deleted_at: NONE
+    }`,
+    {
+      nid: `ORG_${suffix}`,
+      url: `https://github.com/org${suffix}`,
+      login: `org${suffix}`,
+      name: `Org ${suffix}`,
+    },
+  );
+  const orgId = orgRows[0].id;
+
+  const [repoRows] = await db.query<[Array<{ id: unknown }>]>(
+    `CREATE repo CONTENT {
+      github_node_id: $nid,
+      github_url: $url,
+      name: "repo",
+      name_with_owner: $nwo,
+      description: NONE,
+      is_private: false,
+      owner: $orgId,
+      created_at: time::now(),
+      updated_at: time::now(),
+      deleted_at: NONE
+    }`,
+    {
+      nid: `REPO_${suffix}`,
+      url: `https://github.com/org${suffix}/repo`,
+      nwo: `org${suffix}/repo`,
+      orgId,
+    },
+  );
+  return String(repoRows[0].id);
+}
+
+async function setupIssue(db: Db, repoId: string, nodeId: string, number: number): Promise<string> {
+  const [rows] = await db.query<[Array<{ id: unknown }>]>(
+    `CREATE issue CONTENT {
+      github_node_id: $nid,
+      github_url: "https://github.com/test/repo/issues/" + <string>$num,
+      repo: $repo,
+      number: $num,
+      title: $nid,
+      body: NONE,
+      state: "OPEN",
+      state_reason: NONE,
+      author: NONE,
+      closed_at: NONE,
+      created_at: time::now(),
+      updated_at: time::now(),
+      deleted_at: NONE,
+      content_hash: NONE,
+      embedding: NONE
+    }`,
+    { nid: nodeId, num: number, repo: new StringRecordId(repoId) },
+  );
+  return String(rows[0].id);
+}
+
+async function setupPR(db: Db, repoId: string, nodeId: string, number: number): Promise<string> {
+  const [rows] = await db.query<[Array<{ id: unknown }>]>(
+    `CREATE pull_request CONTENT {
+      github_node_id: $nid,
+      github_url: "https://github.com/test/repo/pull/" + <string>$num,
+      repo: $repo,
+      number: $num,
+      title: $nid,
+      body: NONE,
+      state: "OPEN",
+      author: NONE,
+      merged_at: NONE,
+      closed_at: NONE,
+      created_at: time::now(),
+      updated_at: time::now(),
+      deleted_at: NONE,
+      content_hash: NONE,
+      embedding: NONE
+    }`,
+    { nid: nodeId, num: number, repo: new StringRecordId(repoId) },
+  );
+  return String(rows[0].id);
+}
+
+async function setupDiscussion(db: Db, repoId: string, nodeId: string, number: number): Promise<string> {
+  const [rows] = await db.query<[Array<{ id: unknown }>]>(
+    `CREATE discussion CONTENT {
+      github_node_id: $nid,
+      github_url: "https://github.com/test/repo/discussions/" + <string>$num,
+      repo: $repo,
+      number: $num,
+      title: $nid,
+      body: NONE,
+      category: NONE,
+      author: NONE,
+      answer_chosen_at: NONE,
+      created_at: time::now(),
+      updated_at: time::now(),
+      deleted_at: NONE,
+      content_hash: NONE,
+      embedding: NONE
+    }`,
+    { nid: nodeId, num: number, repo: new StringRecordId(repoId) },
+  );
+  return String(rows[0].id);
+}
+
+async function setupComment(db: Db, issueId: string, nodeId: string): Promise<string> {
+  const [rows] = await db.query<[Array<{ id: unknown }>]>(
+    `CREATE comment CONTENT {
+      github_node_id: $nid,
+      github_url: "https://github.com/test/repo/issues/1#issuecomment-1",
+      parent_issue: $issueId,
+      parent_pr: NONE,
+      parent_discussion: NONE,
+      parent_comment: NONE,
+      author: NONE,
+      body: "test comment",
+      created_at: time::now(),
+      updated_at: time::now(),
+      deleted_at: NONE,
+      content_hash: NONE,
+      embedding: NONE
+    }`,
+    { nid: nodeId, issueId: new StringRecordId(issueId) },
+  );
+  return String(rows[0].id);
+}
+
+// ─── 1. Happy path ────────────────────────────────────────────────────────────
+
+describe("reconcileTopLevel — happy path", () => {
+  it("tombstones missing issue and PR; leaves present items and discussion untouched", async () => {
+    await withTestDb(async (db) => {
+      const repoId = await setupRepo(db, "RA");
+      const repo = { id: repoId, name_with_owner: "orgRA/repo" };
+
+      await setupIssue(db, repoId, "I_001", 1);
+      await setupIssue(db, repoId, "I_002", 2);
+      await setupIssue(db, repoId, "I_003", 3);
+      await setupPR(db, repoId, "PR_001", 1);
+      await setupPR(db, repoId, "PR_002", 2);
+      await setupDiscussion(db, repoId, "D_001", 1);
+
+      // GitHub returns I_001, I_002 (missing I_003); PR_001 (missing PR_002); D_001
+      const mockGh = makeMockGh(["I_001", "I_002"], ["PR_001"], ["D_001"]);
+
+      const result = await reconcileTopLevel(db, repo, "orgRA", "repo", mockGh);
+
+      expect(result).toEqual({ issues_tombstoned: 1, prs_tombstoned: 1, discussions_tombstoned: 0 });
+
+      // I_003 should be tombstoned
+      const [i3] = await db.query<[Array<{ is_none: boolean }>]>(
+        "SELECT deleted_at IS NONE AS is_none FROM issue WHERE github_node_id = $id",
+        { id: "I_003" },
+      );
+      expect(i3[0].is_none).toBe(false);
+
+      // I_001 and I_002 should NOT be tombstoned
+      const [i1] = await db.query<[Array<{ is_none: boolean }>]>(
+        "SELECT deleted_at IS NONE AS is_none FROM issue WHERE github_node_id = $id",
+        { id: "I_001" },
+      );
+      expect(i1[0].is_none).toBe(true);
+
+      // PR_002 should be tombstoned
+      const [pr2] = await db.query<[Array<{ is_none: boolean }>]>(
+        "SELECT deleted_at IS NONE AS is_none FROM pull_request WHERE github_node_id = $id",
+        { id: "PR_002" },
+      );
+      expect(pr2[0].is_none).toBe(false);
+
+      // PR_001 should NOT be tombstoned
+      const [pr1] = await db.query<[Array<{ is_none: boolean }>]>(
+        "SELECT deleted_at IS NONE AS is_none FROM pull_request WHERE github_node_id = $id",
+        { id: "PR_001" },
+      );
+      expect(pr1[0].is_none).toBe(true);
+
+      // D_001 should NOT be tombstoned
+      const [d1] = await db.query<[Array<{ is_none: boolean }>]>(
+        "SELECT deleted_at IS NONE AS is_none FROM discussion WHERE github_node_id = $id",
+        { id: "D_001" },
+      );
+      expect(d1[0].is_none).toBe(true);
+    });
+  });
+});
+
+// ─── 2. Idempotency ───────────────────────────────────────────────────────────
+
+describe("reconcileTopLevel — idempotency", () => {
+  it("re-run returns 0 tombstoned and does not update deleted_at timestamp", async () => {
+    await withTestDb(async (db) => {
+      const repoId = await setupRepo(db, "RB");
+      const repo = { id: repoId, name_with_owner: "orgRB/repo" };
+
+      await setupIssue(db, repoId, "I_001", 1);
+      await setupIssue(db, repoId, "I_002", 2);
+      await setupIssue(db, repoId, "I_003", 3);
+      await setupPR(db, repoId, "PR_001", 1);
+      await setupPR(db, repoId, "PR_002", 2);
+      await setupDiscussion(db, repoId, "D_001", 1);
+
+      const mockGh = makeMockGh(["I_001", "I_002"], ["PR_001"], ["D_001"]);
+
+      // First run — tombstones I_003 and PR_002
+      await reconcileTopLevel(db, repo, "orgRB", "repo", mockGh);
+
+      const [afterFirst] = await db.query<[Array<{ deleted_at: unknown }>]>(
+        "SELECT deleted_at FROM issue WHERE github_node_id = $id",
+        { id: "I_003" },
+      );
+      const firstDeletedAt = afterFirst[0].deleted_at;
+      expect(firstDeletedAt).not.toBeNull();
+      expect(firstDeletedAt).not.toBeUndefined();
+
+      // Second run — I_003 and PR_002 are now excluded by `deleted_at IS NONE`
+      const result = await reconcileTopLevel(db, repo, "orgRB", "repo", mockGh);
+      expect(result).toEqual({ issues_tombstoned: 0, prs_tombstoned: 0, discussions_tombstoned: 0 });
+
+      // deleted_at on I_003 must not have changed
+      const [afterSecond] = await db.query<[Array<{ deleted_at: unknown }>]>(
+        "SELECT deleted_at FROM issue WHERE github_node_id = $id",
+        { id: "I_003" },
+      );
+      expect(String(afterSecond[0].deleted_at)).toBe(String(firstDeletedAt));
+    });
+  });
+});
+
+// ─── 3. Passive cascade ───────────────────────────────────────────────────────
+
+describe("reconcileTopLevel — passive cascade", () => {
+  it("comments under a tombstoned issue retain deleted_at = NONE", async () => {
+    await withTestDb(async (db) => {
+      const repoId = await setupRepo(db, "RC");
+      const repo = { id: repoId, name_with_owner: "orgRC/repo" };
+
+      // I_003 is the one that will be tombstoned; it has a comment
+      const issue3Id = await setupIssue(db, repoId, "I_003", 3);
+      await setupComment(db, issue3Id, "C_001");
+
+      await setupIssue(db, repoId, "I_001", 1);
+      await setupIssue(db, repoId, "I_002", 2);
+      await setupPR(db, repoId, "PR_001", 1);
+      await setupPR(db, repoId, "PR_002", 2);
+      await setupDiscussion(db, repoId, "D_001", 1);
+
+      const mockGh = makeMockGh(["I_001", "I_002"], ["PR_001"], ["D_001"]);
+      await reconcileTopLevel(db, repo, "orgRC", "repo", mockGh);
+
+      // Verify I_003 is tombstoned
+      const [i3] = await db.query<[Array<{ is_none: boolean }>]>(
+        "SELECT deleted_at IS NONE AS is_none FROM issue WHERE github_node_id = $id",
+        { id: "I_003" },
+      );
+      expect(i3[0].is_none).toBe(false);
+
+      // Verify comment C_001 still has deleted_at IS NONE (passive cascade)
+      const [c1] = await db.query<[Array<{ is_none: boolean }>]>(
+        "SELECT deleted_at IS NONE AS is_none FROM comment WHERE github_node_id = $id",
+        { id: "C_001" },
+      );
+      expect(c1[0].is_none).toBe(true);
+    });
+  });
+});

--- a/src/ingest/reconcile.ts
+++ b/src/ingest/reconcile.ts
@@ -142,7 +142,13 @@ export async function reconcileTopLevel(
     }
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
-    if (/discuss/i.test(msg) || /disabled/i.test(msg) || /not enabled/i.test(msg)) {
+    // Both conditions required: skip only when GitHub explicitly says
+    // discussions are disabled. A bare "disabled" or "not enabled" can
+    // come from rate limits, deprecated tokens, etc., and must not be
+    // silently swallowed.
+    const looksDisabled =
+      /discussion/i.test(msg) && /(disabled|not enabled|not available)/i.test(msg);
+    if (looksDisabled) {
       console.log(`! Discussions not available for ${owner}/${name}, skipping`);
     } else {
       throw err;

--- a/src/ingest/reconcile.ts
+++ b/src/ingest/reconcile.ts
@@ -1,0 +1,154 @@
+import { StringRecordId } from "surrealdb";
+import type { Surreal } from "surrealdb";
+import type { RepoRef } from "./types.ts";
+
+type GhFn = <T>(query: string, params?: Record<string, unknown>) => Promise<T>;
+
+type Connection = {
+  nodes: Array<{ id: string }>;
+  pageInfo: { hasNextPage: boolean; endCursor: string | null };
+};
+
+const ISSUE_IDS_QUERY = `
+  query FetchIssueIds($owner: String!, $name: String!, $cursor: String) {
+    repository(owner: $owner, name: $name) {
+      issues(first: 100, after: $cursor, states: [OPEN, CLOSED]) {
+        pageInfo { hasNextPage endCursor }
+        nodes { id }
+      }
+    }
+  }
+`;
+
+const PR_IDS_QUERY = `
+  query FetchPrIds($owner: String!, $name: String!, $cursor: String) {
+    repository(owner: $owner, name: $name) {
+      pullRequests(first: 100, after: $cursor, states: [OPEN, CLOSED, MERGED]) {
+        pageInfo { hasNextPage endCursor }
+        nodes { id }
+      }
+    }
+  }
+`;
+
+const DISCUSSION_IDS_QUERY = `
+  query FetchDiscussionIds($owner: String!, $name: String!, $cursor: String) {
+    repository(owner: $owner, name: $name) {
+      discussions(first: 100, after: $cursor) {
+        pageInfo { hasNextPage endCursor }
+        nodes { id }
+      }
+    }
+  }
+`;
+
+async function fetchAllRemoteIds(
+  gh: GhFn,
+  query: string,
+  owner: string,
+  name: string,
+  selectConn: (data: unknown) => Connection,
+): Promise<Set<string>> {
+  const ids = new Set<string>();
+  let cursor: string | null = null;
+  while (true) {
+    const data = await gh<unknown>(query, { owner, name, cursor });
+    const conn = selectConn(data);
+    for (const node of conn.nodes) {
+      ids.add(node.id);
+    }
+    if (!conn.pageInfo.hasNextPage) break;
+    cursor = conn.pageInfo.endCursor;
+  }
+  return ids;
+}
+
+export async function reconcileTopLevel(
+  db: Surreal,
+  repo: RepoRef,
+  owner: string,
+  name: string,
+  gh: GhFn,
+): Promise<{ issues_tombstoned: number; prs_tombstoned: number; discussions_tombstoned: number }> {
+  const repoId = new StringRecordId(repo.id);
+
+  // issues
+  const remoteIssueIds = await fetchAllRemoteIds(
+    gh,
+    ISSUE_IDS_QUERY,
+    owner,
+    name,
+    (d) => (d as { repository: { issues: Connection } }).repository.issues,
+  );
+  const [localIssues] = await db.query<[Array<{ id: unknown; github_node_id: string }>]>(
+    "SELECT id, github_node_id FROM issue WHERE repo = $repo AND deleted_at IS NONE",
+    { repo: repoId },
+  );
+  let issues_tombstoned = 0;
+  for (const row of localIssues) {
+    if (!remoteIssueIds.has(row.github_node_id)) {
+      await db.query("UPDATE $id SET deleted_at = time::now()", {
+        id: new StringRecordId(String(row.id)),
+      });
+      issues_tombstoned++;
+    }
+  }
+  console.log(`✓ Reconciled issue: ${issues_tombstoned} tombstoned`);
+
+  // pull_requests
+  const remotePrIds = await fetchAllRemoteIds(
+    gh,
+    PR_IDS_QUERY,
+    owner,
+    name,
+    (d) => (d as { repository: { pullRequests: Connection } }).repository.pullRequests,
+  );
+  const [localPRs] = await db.query<[Array<{ id: unknown; github_node_id: string }>]>(
+    "SELECT id, github_node_id FROM pull_request WHERE repo = $repo AND deleted_at IS NONE",
+    { repo: repoId },
+  );
+  let prs_tombstoned = 0;
+  for (const row of localPRs) {
+    if (!remotePrIds.has(row.github_node_id)) {
+      await db.query("UPDATE $id SET deleted_at = time::now()", {
+        id: new StringRecordId(String(row.id)),
+      });
+      prs_tombstoned++;
+    }
+  }
+  console.log(`✓ Reconciled pull_request: ${prs_tombstoned} tombstoned`);
+
+  // discussions — skip if disabled on this repo
+  let discussions_tombstoned = 0;
+  try {
+    const remoteDiscIds = await fetchAllRemoteIds(
+      gh,
+      DISCUSSION_IDS_QUERY,
+      owner,
+      name,
+      (d) => (d as { repository: { discussions: Connection } }).repository.discussions,
+    );
+    const [localDiscs] = await db.query<[Array<{ id: unknown; github_node_id: string }>]>(
+      "SELECT id, github_node_id FROM discussion WHERE repo = $repo AND deleted_at IS NONE",
+      { repo: repoId },
+    );
+    for (const row of localDiscs) {
+      if (!remoteDiscIds.has(row.github_node_id)) {
+        await db.query("UPDATE $id SET deleted_at = time::now()", {
+          id: new StringRecordId(String(row.id)),
+        });
+        discussions_tombstoned++;
+      }
+    }
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (/discuss/i.test(msg) || /disabled/i.test(msg) || /not enabled/i.test(msg)) {
+      console.log(`! Discussions not available for ${owner}/${name}, skipping`);
+    } else {
+      throw err;
+    }
+  }
+  console.log(`✓ Reconciled discussion: ${discussions_tombstoned} tombstoned`);
+
+  return { issues_tombstoned, prs_tombstoned, discussions_tombstoned };
+}


### PR DESCRIPTION
## Summary

Add `--reconcile` flag to `tool sync` that detects and tombstones top-level items (issues, PRs, discussions) deleted upstream on GitHub. Triggered explicitly — not auto on every sync, since incremental sync's partial remote ID set would false-positive every item older than `since`.

Comments and commits cascade passively via the `parent.deleted_at IS NONE` query filters that already live in `inspect`/`search` (per the principle in `ARCHITECTURE.md`). No new schema fields on those rows.

## Changes

**Schema** — `schemas.surrealql` adds `last_reconciled_at` (nullable) on `repo` for visibility/cadence tracking.

**New** — `src/ingest/reconcile.ts` exports `reconcileTopLevel(db, repo, owner, name, gh)`:
- Pages GitHub GraphQL `repository.{issues|pullRequests|discussions}` for `id` only.
- Diffs against `SELECT ... WHERE deleted_at IS NONE` per kind.
- Tombstones orphans (`UPDATE $id SET deleted_at = time::now()`).
- Discussions wrapped in try/catch — repos with discussions disabled skip gracefully (logged, not false-tombstoned).
- Returns `{ issues_tombstoned, prs_tombstoned, discussions_tombstoned }`.

**Sync orchestrator** — parses `--reconcile` independently of `--full`. After step 10 (materialize dangling refs), if flag is set: call `reconcileTopLevel`, write `last_reconciled_at` on success, exit 1 without advancing `last_synced_at` on failure. No-flag path is byte-identical to current behavior.

**Help** — sync line documents `[--full] [--reconcile]`.

## Test plan

- [x] `bun run typecheck` — clean.
- [x] `bun test` — 140 pass / 0 fail (3 new in `reconcile.test.ts`: happy path, idempotency, passive cascade).
- [x] No new dependencies.
- [ ] Manual probe (live infra): `tool sync lfnovo/esperanto --reconcile` first run shows 0 tombstones; mutate one local `github_node_id`, re-run, that row gets `deleted_at` set. **To be run after merge** (requires live SurrealDB + token).

## Out of scope

- Comment-level reconciliation. Cascades passively via parent filters.
- Auto-reconcile on every sync (false-positives during incremental).

Closes #15

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `--reconcile` flag to `tool sync` to tombstone local issues/PRs/discussions deleted on GitHub, and tracks runs via `repo.last_reconciled_at`. Default sync is unchanged; discussions-disabled detection is now stricter to avoid swallowing unrelated "disabled" errors (Linear issue-15).

- New Features
  - `tool sync --reconcile` pages GitHub for top-level node IDs and tombstones local orphans.
  - Skips discussions only when GitHub reports discussions are disabled; other errors propagate.
  - On success sets `repo.last_reconciled_at`; on failure exits non-zero without advancing `last_synced_at`.
  - Help updated: `tool sync owner/name [--full] [--reconcile]`.
  - Tests cover happy path, idempotency, passive cascade, and discussions-disabled handling.

- Migration
  - Adds nullable `last_reconciled_at` to `repo`. Apply the schema before running reconciliation.

<sup>Written for commit 2a2b646cce712ca3ea763eb1dcf2ca4d92c09f11. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

