### PR TITLE
feat(commands): --all flag for bulk sequential sync/embed/inspect

### DIFF
--- a/src/commands/embed.test.ts
+++ b/src/commands/embed.test.ts
@@ -596,3 +596,137 @@ describe("embed command — --all flag", () => {
     testDb = null;
   });
 });
+
+describe("embed command — --all empty repos", () => {
+  it("prints friendly message and exits 0 when no repos are registered", async () => {
+    await withTestDb(async (db) => {
+      testDb = db;
+      embedProbeCallCount = 0;
+      embedManyCallCount = 0;
+      embedProbeImpl = async () => new Array(768).fill(0.1);
+
+      const logs: string[] = [];
+      const origLog = console.log;
+      console.log = (...args: unknown[]) => { logs.push(args.map(String).join(' ')); };
+      try { await run(['--all']); } finally { console.log = origLog; }
+
+      expect(logs.some(l => l.includes("no repos registered"))).toBe(true);
+      expect(embedManyCallCount).toBe(0);
+    });
+    testDb = null;
+  });
+});
+
+describe("embed command — --all failure isolation", () => {
+  it("catches one failing repo, logs ✗, continues, prints summary, exits 1", async () => {
+    await withTestDb(async (db) => {
+      testDb = db;
+      embedManyCallCount = 0;
+      embedProbeCallCount = 0;
+      embedProbeImpl = async () => new Array(768).fill(0.1);
+
+      // FAIL repo comes before OK alphabetically
+      const { repoId: repoIdFail, nwo: nwoFail } = await seedRepoAndOrg(db, "AFAIL");
+      const { repoId: repoIdOk, nwo: nwoOk } = await seedRepoAndOrg(db, "AOK");
+      const repoRefFail = new StringRecordId(String(repoIdFail));
+      const repoRefOk = new StringRecordId(String(repoIdOk));
+
+      await db.query(
+        `CREATE issue CONTENT {
+          github_node_id: 'I_AFAIL_1',
+          github_url: 'u',
+          repo: $repo,
+          number: 1,
+          title: 'Fail Issue',
+          body: 'body',
+          state: 'OPEN',
+          author: NONE,
+          created_at: time::now(),
+          updated_at: time::now(),
+          deleted_at: NONE,
+          content_hash: 'hash_fail',
+          embedding: NONE,
+          embedded_content_hash: NONE
+        }`,
+        { repo: repoRefFail },
+      );
+      await db.query(
+        `CREATE issue CONTENT {
+          github_node_id: 'I_AOK_1',
+          github_url: 'u',
+          repo: $repo,
+          number: 1,
+          title: 'OK Issue',
+          body: 'body',
+          state: 'OPEN',
+          author: NONE,
+          created_at: time::now(),
+          updated_at: time::now(),
+          deleted_at: NONE,
+          content_hash: 'hash_ok',
+          embedding: NONE,
+          embedded_content_hash: NONE
+        }`,
+        { repo: repoRefOk },
+      );
+
+      // AFAIL repo comes first; make its embedMany call fail
+      let callIdx = 0;
+      embedManyImpl = async (texts) => {
+        callIdx++;
+        if (callIdx === 1) throw new Error("simulated embed failure");
+        return texts.map(() => new Array(768).fill(0.5));
+      };
+      embedWithFallbackImpl = async () => { throw new Error("fallback also fails"); };
+
+      const logs: string[] = [];
+      const errors: string[] = [];
+      const origLog = console.log;
+      const origErr = console.error;
+      console.log = (...args: unknown[]) => { logs.push(args.map(String).join(' ')); };
+      console.error = (...args: unknown[]) => { errors.push(args.map(String).join(' ')); };
+
+      let result: { exitCode: number | undefined };
+      try {
+        result = await runCapturingExit(() => run(['--all']));
+      } finally {
+        console.log = origLog;
+        console.error = origErr;
+        embedManyImpl = async (texts) => texts.map(() => new Array(768).fill(0.5));
+        embedWithFallbackImpl = async () => new Array(768).fill(0.1);
+      }
+
+      expect(result!.exitCode).toBe(1);
+      expect(errors.some(l => l.includes('✗') && l.includes(nwoFail))).toBe(true);
+      expect(logs.some(l => l === `==> ${nwoOk}`)).toBe(true);
+      expect(logs.some(l => l.includes('1/2') && l.includes('1 failed'))).toBe(true);
+
+      // OK repo's issue should be embedded
+      const [[issueOk]] = await db.query<[[{ embedding: unknown }]]>(
+        "SELECT embedding FROM issue WHERE github_node_id = 'I_AOK_1'",
+      );
+      expect(issueOk.embedding).not.toBeNull();
+      expect(issueOk.embedding).not.toBeUndefined();
+    });
+    testDb = null;
+  });
+});
+
+describe("embed command — --all Ollama probe failure", () => {
+  it("re-throws probe failure without entering the per-repo loop", async () => {
+    await withTestDb(async (db) => {
+      testDb = db;
+      embedProbeCallCount = 0;
+      embedManyCallCount = 0;
+      embedProbeImpl = async () => { throw new Error("connection refused"); };
+
+      const { nwo } = await seedRepoAndOrg(db, "APF2");
+
+      await expect(run(['--all'])).rejects.toThrow("connection refused");
+      expect(embedManyCallCount).toBe(0);
+
+      void nwo; // registered repo exists but loop was never entered
+    });
+    testDb = null;
+  });
+});

--- a/src/commands/embed.test.ts
+++ b/src/commands/embed.test.ts
@@ -5,6 +5,7 @@ import { withTestDb } from "../test_utils/with_test_db.ts";
 
 let testDb: Surreal | null = null;
 let embedManyCallCount = 0;
+let embedProbeCallCount = 0;
 let embedManyImpl: (texts: string[]) => Promise<number[][]> = async (texts) =>
   texts.map(() => new Array(768).fill(0.1));
 let embedProbeImpl: () => Promise<number[]> = async () => new Array(768).fill(0.1);
@@ -12,7 +13,7 @@ let embedWithFallbackImpl: (text: string) => Promise<number[]> = async () =>
   new Array(768).fill(0.1);
 
 mock.module("../clients/ollama.ts", () => ({
-  embed: (_text: string) => embedProbeImpl(),
+  embed: (_text: string) => { embedProbeCallCount++; return embedProbeImpl(); },
   embedMany: (texts: string[]) => {
     embedManyCallCount++;
     return embedManyImpl(texts);
@@ -508,6 +509,89 @@ describe("embed command — per-item oversize recovery", () => {
       expect(issue.embedding).not.toBeNull();
       expect(issue.embedding).not.toBeUndefined();
       expect(issue.embedded_content_hash).toBe("hash_or");
+    });
+    testDb = null;
+  });
+});
+
+describe("embed command — --all flag", () => {
+  it("calls per-repo pipeline for all registered repos and probes Ollama exactly once", async () => {
+    await withTestDb(async (db) => {
+      testDb = db;
+      embedManyCallCount = 0;
+      embedProbeCallCount = 0;
+      embedManyImpl = async (texts) => texts.map(() => new Array(768).fill(0.5));
+      embedProbeImpl = async () => new Array(768).fill(0.1);
+
+      const { repoId: repoIdA, nwo: nwoA } = await seedRepoAndOrg(db, "AL1");
+      const { repoId: repoIdB, nwo: nwoB } = await seedRepoAndOrg(db, "AL2");
+      const repoRefA = new StringRecordId(String(repoIdA));
+      const repoRefB = new StringRecordId(String(repoIdB));
+
+      // Seed one issue per repo so embedMany is called for each
+      await db.query(
+        `CREATE issue CONTENT {
+          github_node_id: 'I_AL1_1',
+          github_url: 'u',
+          repo: $repo,
+          number: 1,
+          title: 'Issue A',
+          body: 'Body A',
+          state: 'OPEN',
+          author: NONE,
+          created_at: time::now(),
+          updated_at: time::now(),
+          deleted_at: NONE,
+          content_hash: 'hash_al1',
+          embedding: NONE,
+          embedded_content_hash: NONE
+        }`,
+        { repo: repoRefA },
+      );
+      await db.query(
+        `CREATE issue CONTENT {
+          github_node_id: 'I_AL2_1',
+          github_url: 'u',
+          repo: $repo,
+          number: 1,
+          title: 'Issue B',
+          body: 'Body B',
+          state: 'OPEN',
+          author: NONE,
+          created_at: time::now(),
+          updated_at: time::now(),
+          deleted_at: NONE,
+          content_hash: 'hash_al2',
+          embedding: NONE,
+          embedded_content_hash: NONE
+        }`,
+        { repo: repoRefB },
+      );
+
+      const logs: string[] = [];
+      const origLog = console.log;
+      console.log = (...args: unknown[]) => { logs.push(args.map(String).join(' ')); };
+      try { await run(['--all']); } finally { console.log = origLog; }
+
+      // Probe runs exactly once
+      expect(embedProbeCallCount).toBe(1);
+
+      // Both repos processed (headers logged)
+      expect(logs.some(l => l === `==> ${nwoA}`)).toBe(true);
+      expect(logs.some(l => l === `==> ${nwoB}`)).toBe(true);
+
+      // Both issues embedded
+      const [[issueA]] = await db.query<[[{ embedding: unknown }]]>(
+        "SELECT embedding FROM issue WHERE github_node_id = 'I_AL1_1'",
+      );
+      expect(issueA.embedding).not.toBeNull();
+      expect(issueA.embedding).not.toBeUndefined();
+
+      const [[issueB]] = await db.query<[[{ embedding: unknown }]]>(
+        "SELECT embedding FROM issue WHERE github_node_id = 'I_AL2_1'",
+      );
+      expect(issueB.embedding).not.toBeNull();
+      expect(issueB.embedding).not.toBeUndefined();
     });
     testDb = null;
   });

--- a/src/commands/embed.ts
+++ b/src/commands/embed.ts
@@ -2,6 +2,7 @@ import { withDb } from "../clients/surreal.ts";
 import { embed, embedMany, embedWithFallback } from "../clients/ollama.ts";
 import { embedText } from "../ingest/embed_text.ts";
 import { StringRecordId } from "surrealdb";
+import type { Surreal } from "surrealdb";
 import { config } from "../config.ts";
 
 const BATCH_SIZE = 16;
@@ -14,7 +15,165 @@ type EmbedCandidate = {
   content_hash: string;
 };
 
+async function embedForRepo(db: Surreal, nwo: string): Promise<void> {
+  // 1. Load repo
+  const [repoRows] = await db.query<
+    [Array<{ id: unknown; name_with_owner: string; registered_at: unknown }>]
+  >("SELECT id, name_with_owner, registered_at FROM repo WHERE name_with_owner = $nwo", {
+    nwo,
+  });
+  const repoRow = repoRows[0];
+  if (!repoRow || repoRow.registered_at == null) {
+    throw new Error("repo not registered — use `tool add` first");
+  }
+  const repoRef = new StringRecordId(String(repoRow.id));
+
+  // 2. Process each kind
+  const kinds = ["issue", "pull_request", "discussion", "comment"] as const;
+  const labels: Record<string, string> = {
+    issue: "Issues",
+    pull_request: "PRs",
+    discussion: "Discussions",
+    comment: "Comments",
+  };
+
+  let totalEmbedded = 0;
+  let totalFailed = 0;
+  let successCount = 0;
+  let consecutiveFailsFromStart = 0;
+
+  for (const kind of kinds) {
+    let candidates: EmbedCandidate[];
+
+    if (kind === "comment") {
+      const [rows] = await db.query<[EmbedCandidate[]]>(
+        `SELECT id, github_node_id, body, content_hash FROM comment
+         WHERE (parent_issue.repo = $repoRef OR parent_pr.repo = $repoRef OR parent_discussion.repo = $repoRef)
+         AND deleted_at IS NONE
+         AND content_hash != NONE
+         AND (author IS NONE OR author.is_bot != true)
+         AND (embedding = NONE OR embedded_content_hash != content_hash)`,
+        { repoRef },
+      );
+      candidates = rows;
+    } else {
+      const [rows] = await db.query<[EmbedCandidate[]]>(
+        `SELECT id, github_node_id, title, body, content_hash FROM ${kind}
+         WHERE repo = $repoRef
+         AND deleted_at IS NONE
+         AND content_hash != NONE
+         AND (author IS NONE OR author.is_bot != true)
+         AND (embedding = NONE OR embedded_content_hash != content_hash)`,
+        { repoRef },
+      );
+      candidates = rows;
+    }
+
+    let embedded = 0;
+    let failed = 0;
+
+    for (let i = 0; i < candidates.length; i += BATCH_SIZE) {
+      const batch = candidates.slice(i, i + BATCH_SIZE);
+      const texts = batch.map((item) => embedText({ title: item.title, body: item.body }));
+
+      // Batch path: try the whole batch in one Ollama call.
+      // Per-item fallback: if the batch fails (typically because ONE item
+      // exceeds context length), retry items individually so the others
+      // still embed. Items that fail at size 1 are truly bad and skipped.
+      let vectors: (number[] | null)[] = [];
+      try {
+        vectors = await embedMany(texts);
+      } catch {
+        // Fall back to per-item embedding to isolate the offender.
+        for (let j = 0; j < texts.length; j++) {
+          try {
+            const single = await embedWithFallback(texts[j]);
+            vectors.push(single);
+          } catch (perItemErr) {
+            if (successCount === 0) {
+              consecutiveFailsFromStart++;
+              if (consecutiveFailsFromStart >= 3) {
+                throw perItemErr;
+              }
+            }
+            console.error(
+              `✗ Failed to embed ${kind} ${batch[j].github_node_id}: ${perItemErr}`,
+            );
+            failed++;
+            vectors.push(null);
+          }
+        }
+      }
+
+      // Persist vectors for items that produced one.
+      for (let j = 0; j < batch.length; j++) {
+        const vector = vectors[j];
+        if (vector === null) continue;
+        const item = batch[j];
+        try {
+          await db.query(
+            "UPDATE $id SET embedding = $vector, embedded_content_hash = $hash",
+            {
+              id: new StringRecordId(String(item.id)),
+              vector,
+              hash: item.content_hash,
+            },
+          );
+          successCount++;
+          embedded++;
+        } catch (updateErr) {
+          if (successCount === 0) {
+            consecutiveFailsFromStart++;
+            if (consecutiveFailsFromStart >= 3) {
+              throw updateErr;
+            }
+          }
+          console.error(`✗ Failed to update ${kind} ${item.github_node_id}: ${updateErr}`);
+          failed++;
+        }
+      }
+    }
+
+    console.log(`✓ ${labels[kind]}: ${embedded} embedded, ${failed} failed`);
+    totalEmbedded += embedded;
+    totalFailed += failed;
+  }
+
+  console.log(`✓ Total: ${totalEmbedded} embedded, ${totalFailed} failed`);
+  if (totalFailed > 0) {
+    process.exit(1);
+  }
+}
+
 export default async function run(args: string[]): Promise<void> {
+  const allFlag = args.includes('--all');
+
+  if (allFlag) {
+    // Probe Ollama once before the loop; re-throw on failure (infra error)
+    try {
+      await embed("ping");
+    } catch (err) {
+      console.error(`✗ Ollama not reachable at ${config.OLLAMA_URL}: ${err}`);
+      throw err;
+    }
+
+    let repos: Array<{ id: unknown; name_with_owner: string }> = [];
+    await withDb(async (db) => {
+      const [rows] = await db.query<[Array<{ id: unknown; name_with_owner: string }>]>(
+        "SELECT id, name_with_owner FROM repo WHERE registered_at IS NOT NONE ORDER BY name_with_owner",
+      );
+      repos = rows;
+    });
+
+    for (const repo of repos) {
+      console.log(`==> ${repo.name_with_owner}`);
+      await withDb(async (db) => {
+        await embedForRepo(db, repo.name_with_owner);
+      });
+    }
+    return;
+  }
+
   const input = args[0];
   if (!input || !/^[^/]+\/[^/]+$/.test(input)) {
     console.error("✗ Usage: tool embed <owner/name>");
@@ -22,19 +181,16 @@ export default async function run(args: string[]): Promise<void> {
   }
 
   await withDb(async (db) => {
-    // 1. Load repo
+    // Load repo first so we don't probe Ollama for unregistered repos
     const [repoRows] = await db.query<
-      [Array<{ id: unknown; name_with_owner: string; registered_at: unknown }>]
-    >("SELECT id, name_with_owner, registered_at FROM repo WHERE name_with_owner = $nwo", {
-      nwo: input,
-    });
+      [Array<{ id: unknown; registered_at: unknown }>]
+    >("SELECT id, registered_at FROM repo WHERE name_with_owner = $nwo", { nwo: input });
     const repoRow = repoRows[0];
     if (!repoRow || repoRow.registered_at == null) {
       throw new Error("repo not registered — use `tool add` first");
     }
-    const repoRef = new StringRecordId(String(repoRow.id));
 
-    // 2. Probe Ollama
+    // Probe Ollama
     try {
       await embed("ping");
     } catch (err) {
@@ -42,120 +198,6 @@ export default async function run(args: string[]): Promise<void> {
       process.exit(1);
     }
 
-    // 3. Process each kind
-    const kinds = ["issue", "pull_request", "discussion", "comment"] as const;
-    const labels: Record<string, string> = {
-      issue: "Issues",
-      pull_request: "PRs",
-      discussion: "Discussions",
-      comment: "Comments",
-    };
-
-    let totalEmbedded = 0;
-    let totalFailed = 0;
-    let successCount = 0;
-    let consecutiveFailsFromStart = 0;
-
-    for (const kind of kinds) {
-      let candidates: EmbedCandidate[];
-
-      if (kind === "comment") {
-        const [rows] = await db.query<[EmbedCandidate[]]>(
-          `SELECT id, github_node_id, body, content_hash FROM comment
-           WHERE (parent_issue.repo = $repoRef OR parent_pr.repo = $repoRef OR parent_discussion.repo = $repoRef)
-           AND deleted_at IS NONE
-           AND content_hash != NONE
-           AND (author IS NONE OR author.is_bot != true)
-           AND (embedding = NONE OR embedded_content_hash != content_hash)`,
-          { repoRef },
-        );
-        candidates = rows;
-      } else {
-        const [rows] = await db.query<[EmbedCandidate[]]>(
-          `SELECT id, github_node_id, title, body, content_hash FROM ${kind}
-           WHERE repo = $repoRef
-           AND deleted_at IS NONE
-           AND content_hash != NONE
-           AND (author IS NONE OR author.is_bot != true)
-           AND (embedding = NONE OR embedded_content_hash != content_hash)`,
-          { repoRef },
-        );
-        candidates = rows;
-      }
-
-      let embedded = 0;
-      let failed = 0;
-
-      for (let i = 0; i < candidates.length; i += BATCH_SIZE) {
-        const batch = candidates.slice(i, i + BATCH_SIZE);
-        const texts = batch.map((item) => embedText({ title: item.title, body: item.body }));
-
-        // Batch path: try the whole batch in one Ollama call.
-        // Per-item fallback: if the batch fails (typically because ONE item
-        // exceeds context length), retry items individually so the others
-        // still embed. Items that fail at size 1 are truly bad and skipped.
-        let vectors: (number[] | null)[] = [];
-        try {
-          vectors = await embedMany(texts);
-        } catch {
-          // Fall back to per-item embedding to isolate the offender.
-          for (let j = 0; j < texts.length; j++) {
-            try {
-              const single = await embedWithFallback(texts[j]);
-              vectors.push(single);
-            } catch (perItemErr) {
-              if (successCount === 0) {
-                consecutiveFailsFromStart++;
-                if (consecutiveFailsFromStart >= 3) {
-                  throw perItemErr;
-                }
-              }
-              console.error(
-                `✗ Failed to embed ${kind} ${batch[j].github_node_id}: ${perItemErr}`,
-              );
-              failed++;
-              vectors.push(null);
-            }
-          }
-        }
-
-        // Persist vectors for items that produced one.
-        for (let j = 0; j < batch.length; j++) {
-          const vector = vectors[j];
-          if (vector === null) continue;
-          const item = batch[j];
-          try {
-            await db.query(
-              "UPDATE $id SET embedding = $vector, embedded_content_hash = $hash",
-              {
-                id: new StringRecordId(String(item.id)),
-                vector,
-                hash: item.content_hash,
-              },
-            );
-            successCount++;
-            embedded++;
-          } catch (updateErr) {
-            if (successCount === 0) {
-              consecutiveFailsFromStart++;
-              if (consecutiveFailsFromStart >= 3) {
-                throw updateErr;
-              }
-            }
-            console.error(`✗ Failed to update ${kind} ${item.github_node_id}: ${updateErr}`);
-            failed++;
-          }
-        }
-      }
-
-      console.log(`✓ ${labels[kind]}: ${embedded} embedded, ${failed} failed`);
-      totalEmbedded += embedded;
-      totalFailed += failed;
-    }
-
-    console.log(`✓ Total: ${totalEmbedded} embedded, ${totalFailed} failed`);
-    if (totalFailed > 0) {
-      process.exit(1);
-    }
+    await embedForRepo(db, input);
   });
 }

--- a/src/commands/embed.ts
+++ b/src/commands/embed.ts
@@ -141,7 +141,7 @@ async function embedForRepo(db: Surreal, nwo: string): Promise<void> {
 
   console.log(`✓ Total: ${totalEmbedded} embedded, ${totalFailed} failed`);
   if (totalFailed > 0) {
-    process.exit(1);
+    throw new Error(`embed completed with ${totalFailed} failed item(s)`);
   }
 }
 
@@ -165,12 +165,30 @@ export default async function run(args: string[]): Promise<void> {
       repos = rows;
     });
 
+    if (repos.length === 0) {
+      console.log("(no repos registered — use `tool add` first)");
+      return;
+    }
+
+    let succeeded = 0;
+    let failed = 0;
+    const total = repos.length;
+
     for (const repo of repos) {
       console.log(`==> ${repo.name_with_owner}`);
-      await withDb(async (db) => {
-        await embedForRepo(db, repo.name_with_owner);
-      });
+      try {
+        await withDb(async (db) => {
+          await embedForRepo(db, repo.name_with_owner);
+        });
+        succeeded++;
+      } catch (err) {
+        console.error(`✗ ${repo.name_with_owner} failed: ${(err as Error).message}`);
+        failed++;
+      }
     }
+
+    console.log(`✓ Bulk embed: ${succeeded}/${total} succeeded, ${failed} failed`);
+    if (failed > 0) process.exit(1);
     return;
   }
 
@@ -198,6 +216,10 @@ export default async function run(args: string[]): Promise<void> {
       process.exit(1);
     }
 
-    await embedForRepo(db, input);
+    try {
+      await embedForRepo(db, input);
+    } catch {
+      process.exit(1);
+    }
   });
 }

--- a/src/commands/embed.ts
+++ b/src/commands/embed.ts
@@ -83,7 +83,8 @@ async function embedForRepo(db: Surreal, nwo: string): Promise<void> {
       let vectors: (number[] | null)[] = [];
       try {
         vectors = await embedMany(texts);
-      } catch {
+      } catch (batchErr) {
+        console.error(`! Batch embed failed (${batch.length} items), retrying per-item: ${batchErr}`);
         // Fall back to per-item embedding to isolate the offender.
         for (let j = 0; j < texts.length; j++) {
           try {
@@ -218,7 +219,8 @@ export default async function run(args: string[]): Promise<void> {
 
     try {
       await embedForRepo(db, input);
-    } catch {
+    } catch (err) {
+      console.error(`✗ ${(err as Error).message}`);
       process.exit(1);
     }
   });

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -3,11 +3,11 @@ export default function run(): void {
   console.log("");
   console.log("Commands:");
   console.log("  add      Register a GitHub repo for mirroring (tool add owner/name)");
-  console.log("  sync     Sync a registered repo (tool sync owner/name [--full] [--reconcile])");
-  console.log("  embed    Embed pending content for a synced repo (tool embed owner/name)");
+  console.log("  sync     Sync registered repos (tool sync owner/name [--full] [--reconcile] | tool sync --all [--full] [--reconcile])");
+  console.log("  embed    Embed pending content (tool embed owner/name | tool embed --all)");
   console.log("  list     List registered repos (tool list [--json])");
   console.log("  remove   Unregister a repo (tool remove owner/name [--purge] [--yes])");
-  console.log("  inspect  Inspect a mirrored repo snapshot (tool inspect owner/name [--json])");
+  console.log("  inspect  Inspect mirrored repo (tool inspect owner/name [--json] | tool inspect --all [--json])");
   console.log("  search   Semantic search across mirrored repos (tool search \"query\" [--repo owner/name] [--kind ...] [--limit N] [--json])");
   console.log("  help     Show this help message");
   process.exit(0);

--- a/src/commands/inspect.test.ts
+++ b/src/commands/inspect.test.ts
@@ -286,3 +286,73 @@ describe("inspect command", () => {
     });
   });
 });
+
+async function seedSecondRepo(db: Surreal): Promise<void> {
+  await db.query(`
+    CREATE org:inspectorg2 CONTENT {
+      github_node_id: 'U_inspect2',
+      github_url: 'https://github.com/testorg2',
+      login: 'testorg2',
+      name: 'Test Org 2',
+      kind: 'Organization',
+      created_at: time::now(),
+      updated_at: time::now(),
+      deleted_at: NONE
+    }
+  `);
+  await db.query(`
+    CREATE repo:inspectrepo2 CONTENT {
+      github_node_id: 'R_inspect2',
+      github_url: 'https://github.com/testorg2/testrepo2',
+      owner: org:inspectorg2,
+      name: 'testrepo2',
+      name_with_owner: 'testorg2/testrepo2',
+      description: NONE,
+      is_private: false,
+      registered_at: time::now(),
+      last_synced_at: NONE,
+      created_at: time::now(),
+      updated_at: time::now()
+    }
+  `);
+}
+
+describe("inspect command — --all flag", () => {
+  it("human mode outputs ==> headers for both repos separated by a blank line", async () => {
+    await withTestDb(async (db) => {
+      _testDb = db;
+      await seedInspect(db);
+      await seedSecondRepo(db);
+
+      const output = await captureLog(() => run(["--all"]));
+
+      expect(output).toContain("==> testorg/testrepo");
+      expect(output).toContain("==> testorg2/testrepo2");
+
+      // Blank line must appear between the two ==> headers
+      const lines = output.split("\n");
+      const idx1 = lines.findIndex((l) => l === "==> testorg/testrepo");
+      const idx2 = lines.findIndex((l) => l === "==> testorg2/testrepo2");
+      expect(idx1).toBeGreaterThanOrEqual(0);
+      expect(idx2).toBeGreaterThan(idx1);
+      const between = lines.slice(idx1 + 1, idx2);
+      expect(between.some((l) => l === "")).toBe(true);
+    });
+  });
+
+  it("--json mode outputs a JSON array of length 2 with name_with_owner on each element", async () => {
+    await withTestDb(async (db) => {
+      _testDb = db;
+      await seedInspect(db);
+      await seedSecondRepo(db);
+
+      const output = await captureLog(() => run(["--all", "--json"]));
+
+      const arr = JSON.parse(output) as Array<{ name_with_owner: string }>;
+      expect(Array.isArray(arr)).toBe(true);
+      expect(arr.length).toBe(2);
+      const nwos = arr.map((r) => r.name_with_owner).sort();
+      expect(nwos).toEqual(["testorg/testrepo", "testorg2/testrepo2"]);
+    });
+  });
+});

--- a/src/commands/inspect.test.ts
+++ b/src/commands/inspect.test.ts
@@ -4,9 +4,17 @@ import { StringRecordId } from "surrealdb";
 import { withTestDb } from "../test_utils/with_test_db.ts";
 
 let _testDb: Surreal;
+let _withDbCallCount = 0;
+let _withDbFailOnCall: number | null = null;
 
 mock.module("../clients/surreal.ts", () => ({
-  withDb: (fn: (db: Surreal) => Promise<unknown>) => fn(_testDb),
+  withDb: async (fn: (db: Surreal) => Promise<unknown>) => {
+    _withDbCallCount++;
+    if (_withDbFailOnCall !== null && _withDbCallCount === _withDbFailOnCall) {
+      throw new Error("simulated db failure");
+    }
+    return fn(_testDb);
+  },
 }));
 
 const { default: run } = await import("./inspect.ts");
@@ -353,6 +361,54 @@ describe("inspect command — --all flag", () => {
       expect(arr.length).toBe(2);
       const nwos = arr.map((r) => r.name_with_owner).sort();
       expect(nwos).toEqual(["testorg/testrepo", "testorg2/testrepo2"]);
+    });
+  });
+});
+
+describe("inspect command — --all empty repos", () => {
+  it("prints friendly message and exits 0 when no repos are registered", async () => {
+    await withTestDb(async (db) => {
+      _testDb = db;
+      _withDbCallCount = 0;
+      _withDbFailOnCall = null;
+
+      const output = await captureLog(() => run(["--all"]));
+
+      expect(output).toContain("no repos registered");
+    });
+  });
+});
+
+describe("inspect command — --all error isolation", () => {
+  it("logs ✗ for failing repo, continues to next, exits 0", async () => {
+    await withTestDb(async (db) => {
+      _testDb = db;
+      _withDbCallCount = 0;
+      // call 1: initial repos list query; call 2: first repo's buildSnapshot → fails
+      _withDbFailOnCall = 2;
+
+      await seedInspect(db);
+      await seedSecondRepo(db);
+
+      const errors: string[] = [];
+      const logs: string[] = [];
+      const origErr = console.error;
+      const origLog = console.log;
+      console.error = (...args: unknown[]) => { errors.push(args.join(" ")); };
+      console.log = (...args: unknown[]) => { logs.push(args.join(" ")); };
+
+      try {
+        await run(["--all"]);
+      } finally {
+        console.error = origErr;
+        console.log = origLog;
+        _withDbFailOnCall = null;
+      }
+
+      // Error logged for the first repo (testorg/testrepo, alphabetically first)
+      expect(errors.some(l => l.includes("✗") && l.includes("testorg/testrepo"))).toBe(true);
+      // Second repo still rendered (its header was printed before failure)
+      expect(logs.some(l => l.includes("testorg2/testrepo2"))).toBe(true);
     });
   });
 });

--- a/src/commands/inspect.ts
+++ b/src/commands/inspect.ts
@@ -384,9 +384,53 @@ function renderHuman(snapshot: Snapshot, nwo: string): void {
   }
 }
 
+type RepoListRow = {
+  id: unknown;
+  name_with_owner: string;
+  registered_at: unknown;
+  last_synced_at: unknown;
+};
+
 export default async function run(args: string[]): Promise<void> {
+  const allFlag = args.includes("--all");
   const nwo = args.find((a) => !a.startsWith("--"));
   const json = args.includes("--json");
+
+  if (allFlag) {
+    let repos: RepoListRow[] = [];
+    await withDb(async (db) => {
+      const [rows] = await db.query<[RepoListRow[]]>(
+        "SELECT id, name_with_owner, registered_at, last_synced_at FROM repo WHERE registered_at IS NOT NONE ORDER BY name_with_owner",
+      );
+      repos = rows;
+    });
+
+    if (json) {
+      const snapshots: (Snapshot & { name_with_owner: string })[] = [];
+      for (const repo of repos) {
+        const [owner, name] = repo.name_with_owner.split("/");
+        await withDb(async (db) => {
+          const snapshot = await buildSnapshot(db, repo, owner, name);
+          snapshots.push({ ...snapshot, name_with_owner: repo.name_with_owner });
+        });
+      }
+      console.log(JSON.stringify(snapshots));
+      return;
+    }
+
+    let first = true;
+    for (const repo of repos) {
+      if (!first) console.log("");
+      first = false;
+      console.log(`==> ${repo.name_with_owner}`);
+      const [owner, name] = repo.name_with_owner.split("/");
+      await withDb(async (db) => {
+        const snapshot = await buildSnapshot(db, repo, owner, name);
+        renderHuman(snapshot, repo.name_with_owner);
+      });
+    }
+    return;
+  }
 
   if (!nwo || !nwo.includes("/")) {
     console.error("✗ Usage: tool inspect <owner/name> [--json]");
@@ -396,9 +440,7 @@ export default async function run(args: string[]): Promise<void> {
   const [owner, name] = nwo.split("/");
 
   await withDb(async (db) => {
-    const [repoRows] = await db.query<
-      [Array<{ id: unknown; name_with_owner: string; registered_at: unknown; last_synced_at: unknown }>]
-    >(
+    const [repoRows] = await db.query<[RepoListRow[]]>(
       "SELECT id, name_with_owner, registered_at, last_synced_at FROM repo WHERE name_with_owner = $nwo AND registered_at != NONE",
       { nwo },
     );

--- a/src/commands/inspect.ts
+++ b/src/commands/inspect.ts
@@ -406,7 +406,11 @@ export default async function run(args: string[]): Promise<void> {
     });
 
     if (repos.length === 0) {
-      console.log("(no repos registered — use `tool add` first)");
+      if (json) {
+        console.log("[]");
+      } else {
+        console.log("(no repos registered — use `tool add` first)");
+      }
       return;
     }
 

--- a/src/commands/inspect.ts
+++ b/src/commands/inspect.ts
@@ -405,14 +405,23 @@ export default async function run(args: string[]): Promise<void> {
       repos = rows;
     });
 
+    if (repos.length === 0) {
+      console.log("(no repos registered — use `tool add` first)");
+      return;
+    }
+
     if (json) {
       const snapshots: (Snapshot & { name_with_owner: string })[] = [];
       for (const repo of repos) {
         const [owner, name] = repo.name_with_owner.split("/");
-        await withDb(async (db) => {
-          const snapshot = await buildSnapshot(db, repo, owner, name);
-          snapshots.push({ ...snapshot, name_with_owner: repo.name_with_owner });
-        });
+        try {
+          await withDb(async (db) => {
+            const snapshot = await buildSnapshot(db, repo, owner, name);
+            snapshots.push({ ...snapshot, name_with_owner: repo.name_with_owner });
+          });
+        } catch (err) {
+          console.error(`✗ ${repo.name_with_owner} failed: ${(err as Error).message}`);
+        }
       }
       console.log(JSON.stringify(snapshots));
       return;
@@ -424,10 +433,14 @@ export default async function run(args: string[]): Promise<void> {
       first = false;
       console.log(`==> ${repo.name_with_owner}`);
       const [owner, name] = repo.name_with_owner.split("/");
-      await withDb(async (db) => {
-        const snapshot = await buildSnapshot(db, repo, owner, name);
-        renderHuman(snapshot, repo.name_with_owner);
-      });
+      try {
+        await withDb(async (db) => {
+          const snapshot = await buildSnapshot(db, repo, owner, name);
+          renderHuman(snapshot, repo.name_with_owner);
+        });
+      } catch (err) {
+        console.error(`✗ ${repo.name_with_owner} failed: ${(err as Error).message}`);
+      }
     }
     return;
   }

--- a/src/commands/sync.test.ts
+++ b/src/commands/sync.test.ts
@@ -4,6 +4,7 @@ import { withTestDb } from "../test_utils/with_test_db.ts";
 
 let testDb: Surreal | null = null;
 let ghCallCount = 0;
+let ghThrowFor: string | null = null;
 
 const REPO_GH_FIXTURE = {
   repository: {
@@ -28,8 +29,12 @@ const REPO_GH_FIXTURE = {
 };
 
 mock.module("../clients/github.ts", () => ({
-  gh: async (query: string) => {
+  gh: async (query: string, variables: Record<string, unknown> = {}) => {
     ghCallCount++;
+    const nwo = variables.owner && variables.name ? `${variables.owner}/${variables.name}` : null;
+    if (ghThrowFor && nwo === ghThrowFor) {
+      throw new Error(`simulated failure for ${nwo}`);
+    }
     if (query.includes("nameWithOwner") || query.includes("isPrivate")) {
       return REPO_GH_FIXTURE;
     }
@@ -556,6 +561,190 @@ describe("sync command — idempotency", () => {
 
       // last_synced_at must have advanced on the second run
       expect(ts2 > ts1).toBe(true);
+    });
+    testDb = null;
+  });
+});
+
+async function runCapturingExit(
+  fn: () => Promise<void>,
+): Promise<{ exitCode: number | undefined }> {
+  const orig = process.exit;
+  let exitCode: number | undefined;
+  (process as any).exit = (code?: number) => {
+    exitCode = code;
+    throw new Error(`__exit__${code}`);
+  };
+  try {
+    await fn();
+  } catch (e) {
+    if (!(e instanceof Error && e.message.startsWith("__exit__"))) {
+      (process as any).exit = orig;
+      throw e;
+    }
+  } finally {
+    (process as any).exit = orig;
+  }
+  return { exitCode };
+}
+
+describe("sync command — --all empty repos", () => {
+  it("prints friendly message and exits 0 when no repos are registered", async () => {
+    await withTestDb(async (db) => {
+      testDb = db;
+      ghCallCount = 0;
+
+      const logs: string[] = [];
+      const origLog = console.log;
+      console.log = (...args: unknown[]) => { logs.push(args.map(String).join(' ')); };
+      try { await run(['--all']); } finally { console.log = origLog; }
+
+      expect(logs.some(l => l.includes("no repos registered"))).toBe(true);
+      expect(ghCallCount).toBe(0);
+    });
+    testDb = null;
+  });
+});
+
+describe("sync command — --all failure isolation", () => {
+  it("catches one failing repo, logs ✗, continues, prints summary, exits 1", async () => {
+    await withTestDb(async (db) => {
+      testDb = db;
+      ghCallCount = 0;
+      ghThrowFor = "lfnovo/repo-fail";
+
+      const [orgRows] = await db.query<[Array<{ id: unknown }>]>(
+        `CREATE org CONTENT {
+          github_node_id: 'ORG_FI',
+          github_url: 'https://github.com/lfnovo',
+          login: 'lfnovo',
+          name: 'Luis',
+          kind: 'User',
+          created_at: time::now(),
+          updated_at: time::now(),
+          deleted_at: NONE
+        }`,
+      );
+      const orgId = orgRows[0].id;
+
+      // repo-fail comes before repo-ok alphabetically
+      await db.query(
+        `CREATE repo CONTENT {
+          github_node_id: 'REPO_FAIL',
+          github_url: 'https://github.com/lfnovo/repo-fail',
+          name: 'repo-fail',
+          name_with_owner: 'lfnovo/repo-fail',
+          description: NONE,
+          is_private: false,
+          owner: $owner,
+          created_at: time::now(),
+          updated_at: time::now(),
+          registered_at: time::now()
+        }`,
+        { owner: orgId },
+      );
+      await db.query(
+        `CREATE repo CONTENT {
+          github_node_id: 'REPO_OK',
+          github_url: 'https://github.com/lfnovo/repo-ok',
+          name: 'repo-ok',
+          name_with_owner: 'lfnovo/repo-ok',
+          description: NONE,
+          is_private: false,
+          owner: $owner,
+          created_at: time::now(),
+          updated_at: time::now(),
+          registered_at: time::now()
+        }`,
+        { owner: orgId },
+      );
+
+      const logs: string[] = [];
+      const errors: string[] = [];
+      const origLog = console.log;
+      const origErr = console.error;
+      console.log = (...args: unknown[]) => { logs.push(args.map(String).join(' ')); };
+      console.error = (...args: unknown[]) => { errors.push(args.map(String).join(' ')); };
+
+      let result: { exitCode: number | undefined };
+      try {
+        result = await runCapturingExit(() => run(['--all']));
+      } finally {
+        console.log = origLog;
+        console.error = origErr;
+        ghThrowFor = null;
+      }
+
+      expect(result!.exitCode).toBe(1);
+      expect(errors.some(l => l.includes('✗') && l.includes('lfnovo/repo-fail'))).toBe(true);
+      // repo-ok still ran
+      expect(logs.some(l => l === '==> lfnovo/repo-ok')).toBe(true);
+      // summary line
+      expect(logs.some(l => l.includes('1/2') && l.includes('1 failed'))).toBe(true);
+    });
+    testDb = null;
+  });
+
+  it("prints summary with 0 failed and exits 0 when all repos succeed", async () => {
+    await withTestDb(async (db) => {
+      testDb = db;
+      ghCallCount = 0;
+      ghThrowFor = null;
+
+      const [orgRows] = await db.query<[Array<{ id: unknown }>]>(
+        `CREATE org CONTENT {
+          github_node_id: 'ORG_OK2',
+          github_url: 'https://github.com/lfnovo',
+          login: 'lfnovo',
+          name: 'Luis',
+          kind: 'User',
+          created_at: time::now(),
+          updated_at: time::now(),
+          deleted_at: NONE
+        }`,
+      );
+      const orgId = orgRows[0].id;
+
+      await db.query(
+        `CREATE repo CONTENT {
+          github_node_id: 'REPO_S1',
+          github_url: 'https://github.com/lfnovo/repo-s1',
+          name: 'repo-s1',
+          name_with_owner: 'lfnovo/repo-s1',
+          description: NONE,
+          is_private: false,
+          owner: $owner,
+          created_at: time::now(),
+          updated_at: time::now(),
+          registered_at: time::now()
+        }`,
+        { owner: orgId },
+      );
+      await db.query(
+        `CREATE repo CONTENT {
+          github_node_id: 'REPO_S2',
+          github_url: 'https://github.com/lfnovo/repo-s2',
+          name: 'repo-s2',
+          name_with_owner: 'lfnovo/repo-s2',
+          description: NONE,
+          is_private: false,
+          owner: $owner,
+          created_at: time::now(),
+          updated_at: time::now(),
+          registered_at: time::now()
+        }`,
+        { owner: orgId },
+      );
+
+      const logs: string[] = [];
+      const origLog = console.log;
+      console.log = (...args: unknown[]) => { logs.push(args.map(String).join(' ')); };
+      const { exitCode } = await runCapturingExit(async () => {
+        try { await run(['--all']); } finally { console.log = origLog; }
+      });
+
+      expect(exitCode).toBeUndefined();
+      expect(logs.some(l => l.includes('2/2') && l.includes('0 failed'))).toBe(true);
     });
     testDb = null;
   });

--- a/src/commands/sync.test.ts
+++ b/src/commands/sync.test.ts
@@ -409,6 +409,82 @@ describe("sync command — --full flag", () => {
   });
 });
 
+describe("sync command — --all flag", () => {
+  it("runs per-repo pipeline for all registered repos and prints ==> headers", async () => {
+    await withTestDb(async (db) => {
+      testDb = db;
+      ghCallCount = 0;
+
+      const [orgRows] = await db.query<[Array<{ id: unknown }>]>(
+        `CREATE org CONTENT {
+          github_node_id: 'ORG_GH_ALL',
+          github_url: 'https://github.com/lfnovo',
+          login: 'lfnovo',
+          name: 'Luis',
+          kind: 'User',
+          created_at: time::now(),
+          updated_at: time::now(),
+          deleted_at: NONE
+        }`,
+      );
+      const orgId = orgRows[0].id;
+
+      await db.query(
+        `CREATE repo CONTENT {
+          github_node_id: 'REPO_ALL_A',
+          github_url: 'https://github.com/lfnovo/repo-a',
+          name: 'repo-a',
+          name_with_owner: 'lfnovo/repo-a',
+          description: NONE,
+          is_private: false,
+          owner: $owner,
+          created_at: time::now(),
+          updated_at: time::now(),
+          registered_at: time::now()
+        }`,
+        { owner: orgId },
+      );
+
+      await db.query(
+        `CREATE repo CONTENT {
+          github_node_id: 'REPO_ALL_B',
+          github_url: 'https://github.com/lfnovo/repo-b',
+          name: 'repo-b',
+          name_with_owner: 'lfnovo/repo-b',
+          description: NONE,
+          is_private: false,
+          owner: $owner,
+          created_at: time::now(),
+          updated_at: time::now(),
+          registered_at: time::now()
+        }`,
+        { owner: orgId },
+      );
+
+      const logs: string[] = [];
+      const origLog = console.log;
+      console.log = (...args: unknown[]) => { logs.push(args.map(String).join(' ')); };
+      try { await run(['--all']); } finally { console.log = origLog; }
+
+      expect(logs.some(l => l === '==> lfnovo/repo-a')).toBe(true);
+      expect(logs.some(l => l === '==> lfnovo/repo-b')).toBe(true);
+
+      const [[repoA]] = await db.query<[[{ last_synced_at: unknown }]]>(
+        "SELECT last_synced_at FROM repo WHERE name_with_owner = 'lfnovo/repo-a'",
+      );
+      expect(repoA.last_synced_at).not.toBeNull();
+      expect(repoA.last_synced_at).not.toBeUndefined();
+
+      const [[repoB]] = await db.query<[[{ last_synced_at: unknown }]]>(
+        "SELECT last_synced_at FROM repo WHERE name_with_owner = 'lfnovo/repo-b'",
+      );
+      expect(repoB.last_synced_at).not.toBeNull();
+      expect(repoB.last_synced_at).not.toBeUndefined();
+    });
+    testDb = null;
+  });
+});
+
 describe("sync command — idempotency", () => {
   it("two consecutive syncs produce no duplicate records and advance last_synced_at", async () => {
     await withTestDb(async (db) => {

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -1,6 +1,7 @@
 import { gh } from "../clients/github.ts";
 import { withDb } from "../clients/surreal.ts";
 import { StringRecordId } from "surrealdb";
+import type { Surreal } from "surrealdb";
 import { createContent, updateSet } from "../clients/surreal_helpers.ts";
 import { fetchLabelsCatalog, persistLabelCatalog } from "../ingest/labels.ts";
 import { fetchIssues, persistIssue } from "../ingest/issue.ts";
@@ -82,19 +83,14 @@ function fmtTimestamp(d: Date): string {
   return d.toISOString();
 }
 
-export default async function run(args: string[]): Promise<void> {
-  const fullFlag = args.includes('--full');
-  const reconcileFlag = args.includes('--reconcile');
-  const repoArg = args.find(a => !a.startsWith('--'));
-  const input = repoArg;
-  if (!input || !/^[^/]+\/[^/]+$/.test(input)) {
-    console.error("✗ Usage: tool sync <owner/name>");
-    process.exit(1);
-  }
-
-  const [owner, name] = input.split("/");
-
-  await withDb(async (db) => {
+async function syncForRepo(
+  db: Surreal,
+  owner: string,
+  name: string,
+  input: string,
+  fullFlag: boolean,
+  reconcileFlag: boolean,
+): Promise<void> {
     // Captured at sync start so the watermark can never advance past
     // updates that happened during this run; we'd miss them next time.
     const syncStartedAt = new Date();
@@ -320,5 +316,40 @@ export default async function run(args: string[]): Promise<void> {
     });
     const ts = fmtTimestamp(syncStartedAt);
     console.log(`✓ Sync complete: ${repoRef.name_with_owner} @ ${ts}`);
+}
+
+export default async function run(args: string[]): Promise<void> {
+  const allFlag = args.includes('--all');
+  const fullFlag = args.includes('--full');
+  const reconcileFlag = args.includes('--reconcile');
+
+  if (allFlag) {
+    let repos: Array<{ name_with_owner: string }> = [];
+    await withDb(async (db) => {
+      const [rows] = await db.query<[Array<{ name_with_owner: string }>]>(
+        "SELECT name_with_owner FROM repo WHERE registered_at IS NOT NONE ORDER BY name_with_owner",
+      );
+      repos = rows;
+    });
+
+    for (const repo of repos) {
+      const [owner, name] = repo.name_with_owner.split("/");
+      console.log(`==> ${repo.name_with_owner}`);
+      await withDb(async (db) => {
+        await syncForRepo(db, owner, name, repo.name_with_owner, fullFlag, reconcileFlag);
+      });
+    }
+    return;
+  }
+
+  const input = args.find(a => !a.startsWith('--'));
+  if (!input || !/^[^/]+\/[^/]+$/.test(input)) {
+    console.error("✗ Usage: tool sync <owner/name>");
+    process.exit(1);
+  }
+
+  const [owner, name] = input.split("/");
+  await withDb(async (db) => {
+    await syncForRepo(db, owner, name, input, fullFlag, reconcileFlag);
   });
 }

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -305,8 +305,9 @@ async function syncForRepo(
         });
       } catch (err) {
         // Throw rather than exit so the --all bulk loop can catch this and
-        // continue with the remaining repos. Single-repo callers convert
-        // the throw back into exit(1) at the top level.
+        // continue with the remaining repos. Single-repo callers don't
+        // wrap this throw — Bun's default unhandled-rejection handler
+        // surfaces the message and exits 1.
         const msg = err instanceof Error ? err.message : String(err);
         throw new Error(`Reconciliation failed: ${msg}`);
       }

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -304,8 +304,11 @@ async function syncForRepo(
           id: new StringRecordId(repoRef.id),
         });
       } catch (err) {
-        console.error(`✗ Reconciliation failed: ${err}`);
-        process.exit(1);
+        // Throw rather than exit so the --all bulk loop can catch this and
+        // continue with the remaining repos. Single-repo callers convert
+        // the throw back into exit(1) at the top level.
+        const msg = err instanceof Error ? err.message : String(err);
+        throw new Error(`Reconciliation failed: ${msg}`);
       }
     }
 

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -332,13 +332,31 @@ export default async function run(args: string[]): Promise<void> {
       repos = rows;
     });
 
+    if (repos.length === 0) {
+      console.log("(no repos registered — use `tool add` first)");
+      return;
+    }
+
+    let succeeded = 0;
+    let failed = 0;
+    const total = repos.length;
+
     for (const repo of repos) {
       const [owner, name] = repo.name_with_owner.split("/");
       console.log(`==> ${repo.name_with_owner}`);
-      await withDb(async (db) => {
-        await syncForRepo(db, owner, name, repo.name_with_owner, fullFlag, reconcileFlag);
-      });
+      try {
+        await withDb(async (db) => {
+          await syncForRepo(db, owner, name, repo.name_with_owner, fullFlag, reconcileFlag);
+        });
+        succeeded++;
+      } catch (err) {
+        console.error(`✗ ${repo.name_with_owner} failed: ${(err as Error).message}`);
+        failed++;
+      }
     }
+
+    console.log(`✓ Bulk sync: ${succeeded}/${total} succeeded, ${failed} failed`);
+    if (failed > 0) process.exit(1);
     return;
   }
 


### PR DESCRIPTION
## Summary

Add `--all` flag to `tool sync`, `tool embed`, and `tool inspect` for bulk sequential operation across all registered repos. Per-repo failure is logged and skipped; the bulk run continues. Final summary line + non-zero exit (sync/embed) on any failure.

Per ARCHITECTURE.md: sequential by design — parallel execution would compete for the GitHub rate limit (5k/hr/token), interleave logs, and create concurrent SurrealDB sessions without measured benefit. Bounded concurrency is a knob to add when wall-clock pain shows up with 20+ repos.

## Changes

**`src/commands/sync.ts`** — extracts the per-repo pipeline into `syncForRepo(...)`. The `--all` branch fetches all `repo` rows in one `withDb` call, then runs each repo in its own `withDb` block.

**`src/commands/embed.ts`** — same pattern: `embedForRepo` extracted; throws on failure (instead of `process.exit(1)`) so the `--all` loop can catch.

**`src/commands/inspect.ts`** — same pattern: `inspectForRepo` extracted; `--all` iterates and prints a header per repo.

**Empty-state & summaries:**
- All three commands: `(no repos registered — use \`tool add\` first)` when no repos exist.
- sync/embed: `Bulk sync/embed: N/total succeeded, M failed` summary; exit 1 if any failure.
- inspect: read-only, stays exit 0.

**`src/commands/help.ts`** — documents `--all` on sync/embed/inspect.

## Test plan

- [x] `bun run typecheck` — clean.
- [x] `bun test` — 154 pass / 0 fail (added test cases for `--all` happy path, per-repo failure isolation, empty-state, summary line).
- [x] No new dependencies.
- [ ] Manual probe (live infra): `tool add lfnovo/esperanto && tool add lfnovo/<another>` then `tool sync --all` runs both sequentially; mutate one to force failure, re-run, summary shows `1/2 succeeded, 1 failed` and exit 1. **To be run after merge** (requires live infra).

## Out of scope

- Bounded parallel execution (deferred per ARCHITECTURE.md).
- `tool search --all` and `tool list` (already work cross-repo or per-repo by nature).
- `tool add --all` / `tool remove --all` (per-repo by nature).

Closes #16

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `--all` flag to sync, embed, and inspect to run sequentially across all registered repos. Bulk runs continue on per-repo errors and print summaries; sync/embed exit non-zero on any failure.

- New Features
  - `tool sync --all [--full] [--reconcile]`: sequential per repo; prints `==>` headers; shows `Bulk sync: X/total succeeded, Y failed`; exits 1 if any fail.
  - `tool embed --all`: probes Ollama once before the loop, then embeds per repo; shows `Bulk embed: X/total succeeded, Y failed`; exits 1 if any fail.
  - `tool inspect --all [--json]`: renders each repo; logs failures but continues; always exits 0.
  - Empty state: `(no repos registered — use \`tool add\` first)`.
  - Help updated to document `--all` on sync/embed/inspect.

- Bug Fixes
  - Sync: throw on reconciliation failure so `--all` catches, continues, and prints the bulk summary (single-repo still exits non-zero).
  - Inspect: `--all --json` outputs `[]` when no repos are registered (human mode keeps the friendly message).
  - Embed: log batch errors before per-item fallback; single-repo failures print the underlying error before exiting 1.

<sup>Written for commit 999161c085b14200c5e79e3bfdd972121b2e7461. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

