### PR TITLE
feat: private-repo support — docs, 401 hint, and manual verification

### DIFF
--- a/MANUAL_VERIFICATION.md
+++ b/MANUAL_VERIFICATION.md
@@ -1,0 +1,54 @@
+## Manual verification
+
+Performed against `lfnovo/circle-bilu` (a real private repository under the operator's account), using the GitHub token configured in the environment.
+
+### Step 1 — `tool add`
+
+```
+$ bun run src/index.ts add lfnovo/circle-bilu
+✓ Registered lfnovo/circle-bilu (repo:44lipo7htj1xy05baian)
+```
+
+### Step 2 — `tool sync`
+
+```
+$ bun run src/index.ts sync lfnovo/circle-bilu
+Sync mode: full
+✓ Labels (catalog): 9 persisted
+✓ Issues: 0 persisted
+✓ Pull requests: 0 persisted (0 commits)
+✓ Discussions: 0 persisted
+✓ Comments (issues): 0 persisted, 0 tombstoned
+✓ Comments (PRs): 0 persisted, 0 tombstoned
+✓ Comments (discussions): 0 persisted, 0 tombstoned
+✓ Cross-refs: 0 same-repo, 0 cross-repo, 0 dangling
+✓ Answer links: 0 resolved, 0 pending
+✓ Dangling materialized: 0
+✓ Sync complete: lfnovo/circle-bilu @ 2026-05-07T01:07:30.760Z
+```
+
+### Step 3 — SurrealDB query
+
+```sql
+SELECT name_with_owner, is_private FROM repo WHERE name_with_owner = "lfnovo/circle-bilu"
+```
+
+Result:
+
+```json
+[{"result":[{"is_private":true,"name_with_owner":"lfnovo/circle-bilu"}],"status":"OK","time":"335.458µs"}]
+```
+
+`is_private: true` confirmed on the persisted row.
+
+### Step 4 — 401 hint with invalid token
+
+```
+$ GITHUB_TOKEN=bad_token_intentionally_invalid bun run src/index.ts add lfnovo/circle-bilu
+error: ✗ GitHub access denied for lfnovo/circle-bilu: Bad credentials - https://docs.github.com/rest
+  Hint: token may be expired, missing required scope, or not authorized
+        for this org. See README "Private repos" for required scopes.
+      at gh (.../src/clients/github.ts:30:17)
+      at async run (.../src/commands/add.ts:71:22)
+(exit code 1)
+```

--- a/MANUAL_VERIFICATION.md
+++ b/MANUAL_VERIFICATION.md
@@ -1,18 +1,18 @@
 ## Manual verification
 
-Performed against `lfnovo/circle-bilu` (a real private repository under the operator's account), using the GitHub token configured in the environment.
+Performed against `<owner>/<private-test-repo>` (a real private repository under the operator's account), using the GitHub token configured in the environment.
 
 ### Step 1 — `tool add`
 
 ```
-$ bun run src/index.ts add lfnovo/circle-bilu
-✓ Registered lfnovo/circle-bilu (repo:44lipo7htj1xy05baian)
+$ bun run src/index.ts add <owner>/<private-test-repo>
+✓ Registered <owner>/<private-test-repo> (repo:44lipo7htj1xy05baian)
 ```
 
 ### Step 2 — `tool sync`
 
 ```
-$ bun run src/index.ts sync lfnovo/circle-bilu
+$ bun run src/index.ts sync <owner>/<private-test-repo>
 Sync mode: full
 ✓ Labels (catalog): 9 persisted
 ✓ Issues: 0 persisted
@@ -24,19 +24,19 @@ Sync mode: full
 ✓ Cross-refs: 0 same-repo, 0 cross-repo, 0 dangling
 ✓ Answer links: 0 resolved, 0 pending
 ✓ Dangling materialized: 0
-✓ Sync complete: lfnovo/circle-bilu @ 2026-05-07T01:07:30.760Z
+✓ Sync complete: <owner>/<private-test-repo> @ 2026-05-07T01:07:30.760Z
 ```
 
 ### Step 3 — SurrealDB query
 
 ```sql
-SELECT name_with_owner, is_private FROM repo WHERE name_with_owner = "lfnovo/circle-bilu"
+SELECT name_with_owner, is_private FROM repo WHERE name_with_owner = "<owner>/<private-test-repo>"
 ```
 
 Result:
 
 ```json
-[{"result":[{"is_private":true,"name_with_owner":"lfnovo/circle-bilu"}],"status":"OK","time":"335.458µs"}]
+[{"result":[{"is_private":true,"name_with_owner":"<owner>/<private-test-repo>"}],"status":"OK","time":"335.458µs"}]
 ```
 
 `is_private: true` confirmed on the persisted row.
@@ -44,8 +44,8 @@ Result:
 ### Step 4 — 401 hint with invalid token
 
 ```
-$ GITHUB_TOKEN=bad_token_intentionally_invalid bun run src/index.ts add lfnovo/circle-bilu
-error: ✗ GitHub access denied for lfnovo/circle-bilu: Bad credentials - https://docs.github.com/rest
+$ GITHUB_TOKEN=bad_token_intentionally_invalid bun run src/index.ts add <owner>/<private-test-repo>
+error: ✗ GitHub access denied for <owner>/<private-test-repo>: Bad credentials - https://docs.github.com/rest
   Hint: token may be expired, missing required scope, or not authorized
         for this org. See README "Private repos" for required scopes.
       at gh (.../src/clients/github.ts:30:17)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,32 @@
 `github-embedder-surrealdb` is a read-only GitHub knowledge-base mirror stored as a graph in SurrealDB and exposed as a Bun CLI. It mirrors discussion artifacts of one or more GitHub repositories — issues, PRs, discussions, comments, and PR-referenced commits — so an AI agent can semantically retrieve project memory about what has already been discussed, decided, or attempted.
 
+## Configuration
+
+### Private repos
+
+The mirror works with private repositories out of the box — `tool add`, `tool sync`, and `tool embed` make no public/private distinction. The `is_private` field is captured and stored automatically.
+
+To access private repos, the `GITHUB_TOKEN` must have the right permissions:
+
+**Classic PAT** — needs the `repo` scope.
+
+**Fine-grained PAT** — needs all of the following repository permissions:
+- `contents:read`
+- `issues:read`
+- `pull-requests:read`
+- `discussions:read`
+- `metadata:read`
+
+See GitHub's docs for guidance:
+- [Managing personal access tokens (classic)](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens)
+- [Creating a fine-grained personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-fine-grained-personal-access-token)
+
+**Organization-owned repos** — an org admin may need to authorize (approve) the PAT for the organization before it can access org repos.
+
+**SSO-protected repos** — if the org enforces SAML SSO, the PAT must also have SSO authorized for the relevant organization.
+
+**Single-token constraint** — the same token must cover every repository registered in this install. If you need different tokens for repos under different accounts (e.g., a personal repo and a different org's repo), that is tracked as a separate future enhancement: [#42 Per-repo tokens for multi-account / fine-grained PAT installs](https://github.com/lfnovo/repo-embed/issues/42).
+
 ## Testing
 
 ### Running tests

--- a/src/clients/github.test.ts
+++ b/src/clients/github.test.ts
@@ -128,4 +128,20 @@ describe("gh() 401/403 diagnostic wrapping", () => {
     };
     await expect(gh("query { }")).rejects.toBe(graphqlErr);
   });
+
+  it("re-throws 403 rate-limit errors unchanged (no scope hint)", async () => {
+    const rateErr = makeHttpError(403, "API rate limit exceeded for user ID 1");
+    mockImpl = async () => {
+      throw rateErr;
+    };
+    await expect(gh("query { }")).rejects.toBe(rateErr);
+  });
+
+  it("re-throws 403 secondary rate-limit (abuse) errors unchanged", async () => {
+    const abuseErr = makeHttpError(403, "You have exceeded a secondary rate limit. Please wait a few minutes before you try again.");
+    mockImpl = async () => {
+      throw abuseErr;
+    };
+    await expect(gh("query { }")).rejects.toBe(abuseErr);
+  });
 });

--- a/src/clients/github.test.ts
+++ b/src/clients/github.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, mock, beforeEach } from "bun:test";
+
+// Mutable reference so each test can control what the mock returns/throws
+let mockImpl: (query: string, params?: unknown) => Promise<unknown> = async () => ({});
+
+const mockGqlFn = Object.assign(
+  (query: string, params?: unknown) => mockImpl(query, params),
+  { defaults: (_opts: unknown) => mockGqlFn },
+);
+
+mock.module("@octokit/graphql", () => ({ graphql: mockGqlFn }));
+mock.module("../config.ts", () => ({
+  requireGithubToken: () => "fake-token",
+  config: {
+    GITHUB_TOKEN: "fake-token",
+    SURREAL_URL: "http://localhost:8018/rpc",
+    SURREAL_NS: "githubembed",
+    SURREAL_DB: "main",
+    SURREAL_USER: "root",
+    SURREAL_PASS: "root",
+    OLLAMA_URL: "http://localhost:11434",
+    OLLAMA_EMBED_MODEL: "nomic-embed-text",
+    EMBED_DIM: 768,
+  },
+}));
+
+const { gh } = await import("./github.ts");
+
+function makeHttpError(status: number, message: string): Error {
+  const err = new Error(message);
+  (err as unknown as { status: number }).status = status;
+  return err;
+}
+
+beforeEach(() => {
+  mockImpl = async () => ({});
+});
+
+describe("gh() 401/403 diagnostic wrapping", () => {
+  it("returns response on success", async () => {
+    mockImpl = async () => ({ repository: { name: "test" } });
+    const result = await gh<{ repository: { name: string } }>("query { }");
+    expect(result).toEqual({ repository: { name: "test" } });
+  });
+
+  it("wraps 401 error with diagnostic hint", async () => {
+    mockImpl = async () => {
+      throw makeHttpError(401, "Bad credentials");
+    };
+    await expect(gh("query { }")).rejects.toThrow(
+      "token may be expired, missing required scope, or not authorized",
+    );
+  });
+
+  it("wraps 403 error with diagnostic hint", async () => {
+    mockImpl = async () => {
+      throw makeHttpError(403, "Forbidden");
+    };
+    await expect(gh("query { }")).rejects.toThrow(
+      "token may be expired, missing required scope, or not authorized",
+    );
+  });
+
+  it("includes repo identifier when owner and name params present", async () => {
+    mockImpl = async () => {
+      throw makeHttpError(401, "Bad credentials");
+    };
+    await expect(
+      gh("query { }", { owner: "myorg", name: "myrepo" }),
+    ).rejects.toThrow("GitHub access denied for myorg/myrepo");
+  });
+
+  it("omits repo identifier when params are absent", async () => {
+    mockImpl = async () => {
+      throw makeHttpError(401, "Bad credentials");
+    };
+    let caught: Error | null = null;
+    try {
+      await gh("query { }");
+    } catch (e) {
+      caught = e as Error;
+    }
+    expect(caught).not.toBeNull();
+    expect(caught!.message).toContain("GitHub access denied:");
+    expect(caught!.message).not.toMatch(/for \S+\/\S+/);
+  });
+
+  it("chains original error as cause", async () => {
+    const original = makeHttpError(401, "Bad credentials");
+    mockImpl = async () => {
+      throw original;
+    };
+    let caught: unknown = null;
+    try {
+      await gh("query { }");
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).not.toBeNull();
+    expect((caught as { cause: unknown }).cause).toBe(original);
+  });
+
+  it("re-throws 500 errors unchanged", async () => {
+    const err500 = makeHttpError(500, "Internal server error");
+    mockImpl = async () => {
+      throw err500;
+    };
+    await expect(gh("query { }")).rejects.toBe(err500);
+  });
+
+  it("re-throws errors without status unchanged", async () => {
+    const plainErr = new Error("Something went wrong");
+    mockImpl = async () => {
+      throw plainErr;
+    };
+    await expect(gh("query { }")).rejects.toBe(plainErr);
+  });
+
+  it("re-throws GraphqlResponseError (no status field) unchanged", async () => {
+    // GraphqlResponseError has no numeric status — only request/headers/response/errors/data
+    const graphqlErr = Object.assign(new Error("Request failed due to response errors"), {
+      name: "GraphqlResponseError",
+      errors: [{ message: "Could not resolve to a Repository" }],
+      data: { repository: null },
+    });
+    mockImpl = async () => {
+      throw graphqlErr;
+    };
+    await expect(gh("query { }")).rejects.toBe(graphqlErr);
+  });
+});

--- a/src/clients/github.ts
+++ b/src/clients/github.ts
@@ -12,8 +12,28 @@ function getGh(): typeof graphql {
   return _gh;
 }
 
-export function gh<T>(query: string, params?: RequestParameters): Promise<T> {
-  return getGh()<T>(query, params);
+export async function gh<T>(query: string, params?: RequestParameters): Promise<T> {
+  try {
+    return await getGh()<T>(query, params);
+  } catch (err: unknown) {
+    if (
+      err !== null &&
+      typeof err === "object" &&
+      "status" in err &&
+      ((err as { status: unknown }).status === 401 ||
+        (err as { status: unknown }).status === 403)
+    ) {
+      const owner = typeof params?.owner === "string" ? params.owner : null;
+      const name = typeof params?.name === "string" ? params.name : null;
+      const repo = owner && name ? ` for ${owner}/${name}` : "";
+      const originalMessage = err instanceof Error ? err.message : String(err);
+      throw new Error(
+        `✗ GitHub access denied${repo}: ${originalMessage}\n  Hint: token may be expired, missing required scope, or not authorized\n        for this org. See README "Private repos" for required scopes.`,
+        { cause: err },
+      );
+    }
+    throw err;
+  }
 }
 
 /**

--- a/src/clients/github.ts
+++ b/src/clients/github.ts
@@ -23,10 +23,18 @@ export async function gh<T>(query: string, params?: RequestParameters): Promise<
       ((err as { status: unknown }).status === 401 ||
         (err as { status: unknown }).status === 403)
     ) {
+      const originalMessage = err instanceof Error ? err.message : String(err);
+      // GitHub uses 403 for both auth/scope errors AND rate limits
+      // (primary and secondary/abuse). Don't paint a scope-hint over
+      // a throttle — surface the original error so the operator sees
+      // the rate-limit signal instead of a misleading auth message.
+      const looksLikeRateLimit = /rate limit|abuse|secondary rate/i.test(originalMessage);
+      if (looksLikeRateLimit) {
+        throw err;
+      }
       const owner = typeof params?.owner === "string" ? params.owner : null;
       const name = typeof params?.name === "string" ? params.name : null;
       const repo = owner && name ? ` for ${owner}/${name}` : "";
-      const originalMessage = err instanceof Error ? err.message : String(err);
       throw new Error(
         `✗ GitHub access denied${repo}: ${originalMessage}\n  Hint: token may be expired, missing required scope, or not authorized\n        for this org. See README "Private repos" for required scopes.`,
         { cause: err },

--- a/src/commands/add.test.ts
+++ b/src/commands/add.test.ts
@@ -5,8 +5,30 @@ import fixture from "./__fixtures__/repository_lfnovo_esperanto.json";
 
 let _testDb: Surreal;
 
+let ghImpl: (query: string, params?: unknown) => Promise<unknown> = async () =>
+  fixture;
 mock.module("../clients/github.ts", () => ({
-  gh: async () => fixture,
+  gh: async (...args: Parameters<typeof ghImpl>) => {
+    try {
+      return await ghImpl(...args);
+    } catch (err: unknown) {
+      if (
+        err !== null &&
+        typeof err === "object" &&
+        "status" in err &&
+        ((err as { status: unknown }).status === 401 ||
+          (err as { status: unknown }).status === 403)
+      ) {
+        const originalMessage =
+          err instanceof Error ? err.message : String(err);
+        throw new Error(
+          `✗ GitHub access denied: ${originalMessage}\n  Hint: token may be expired, missing required scope, or not authorized for this org.`,
+          { cause: err },
+        );
+      }
+      throw err;
+    }
+  },
 }));
 
 mock.module("../clients/surreal.ts", () => ({
@@ -61,6 +83,39 @@ describe("add command", () => {
 
       expect(secondValue).toBe(firstValue);
     });
+  });
+
+  it("persists is_private=true for a private repo", async () => {
+    const privateFixture = {
+      repository: { ...fixture.repository, isPrivate: true },
+    };
+    ghImpl = async () => privateFixture;
+    await withTestDb(async (db) => {
+      _testDb = db;
+
+      await run(["lfnovo/esperanto"]);
+
+      const [repoRows] = await db.query<[Array<{ is_private: boolean }>]>(
+        "SELECT is_private FROM repo WHERE name_with_owner = 'lfnovo/esperanto'",
+      );
+      expect(repoRows.length).toBe(1);
+      expect(repoRows[0].is_private).toBe(true);
+    });
+    ghImpl = async () => fixture;
+  });
+
+  it("rejects with 401 hint when gh throws a 401 error", async () => {
+    ghImpl = async () => {
+      throw Object.assign(new Error("Bad credentials"), { status: 401 });
+    };
+    await withTestDb(async (db) => {
+      _testDb = db;
+
+      await expect(run(["lfnovo/esperanto"])).rejects.toThrow(
+        "token may be expired",
+      );
+    });
+    ghImpl = async () => fixture;
   });
 
   it("exits 1 on bad arg (empty args)", async () => {


### PR DESCRIPTION
## Summary

Closes #17

Three deliverables that turn the mirror's implicit private-repo support into explicit support:

- **README.md**: new `## Configuration / ### Private repos` subsection documenting required token scopes (classic PAT `repo`, fine-grained PAT permissions, org/SSO notes, single-token constraint).
- **`src/clients/github.ts`**: `gh()` now catches HTTP 401/403 errors and re-throws with a diagnostic hint pointing operators at the README section. Original error is chained as `cause`.
- **Tests**: two new cases in `add.test.ts` — private-repo happy path (`is_private: true` persisted) and 401 error hint format.

## Manual verification

Performed against `lfnovo/circle-bilu` (a real private repository under the operator's account), using the GitHub token configured in the environment.

### Step 1 — `tool add`

```
$ bun run src/index.ts add lfnovo/circle-bilu
✓ Registered lfnovo/circle-bilu (repo:44lipo7htj1xy05baian)
```

### Step 2 — `tool sync`

```
$ bun run src/index.ts sync lfnovo/circle-bilu
Sync mode: full
✓ Labels (catalog): 9 persisted
✓ Issues: 0 persisted
✓ Pull requests: 0 persisted (0 commits)
✓ Discussions: 0 persisted
✓ Comments (issues): 0 persisted, 0 tombstoned
✓ Comments (PRs): 0 persisted, 0 tombstoned
✓ Comments (discussions): 0 persisted, 0 tombstoned
✓ Cross-refs: 0 same-repo, 0 cross-repo, 0 dangling
✓ Answer links: 0 resolved, 0 pending
✓ Dangling materialized: 0
✓ Sync complete: lfnovo/circle-bilu @ 2026-05-07T01:07:30.760Z
```

### Step 3 — SurrealDB query

```sql
SELECT name_with_owner, is_private FROM repo WHERE name_with_owner = "lfnovo/circle-bilu"
```

Result:

```json
[{"result":[{"is_private":true,"name_with_owner":"lfnovo/circle-bilu"}],"status":"OK","time":"335.458µs"}]
```

`is_private: true` confirmed on the persisted row.

### Step 4 — 401 hint with invalid token

```
$ GITHUB_TOKEN=bad_token_intentionally_invalid bun run src/index.ts add lfnovo/circle-bilu
error: ✗ GitHub access denied for lfnovo/circle-bilu: Bad credentials - https://docs.github.com/rest
  Hint: token may be expired, missing required scope, or not authorized
        for this org. See README "Private repos" for required scopes.
      at gh (.../src/clients/github.ts:30:17)
      at async run (.../src/commands/add.ts:71:22)
(exit code 1)
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds explicit private-repo support with docs and a manual verification guide, plus clearer GitHub client errors with 401/403 hints while letting 403 rate‑limit errors pass through. Closes #17.

- **New Features**
  - Docs: `README.md` → Configuration/Private repos (scopes, org/SSO, single‑token); `MANUAL_VERIFICATION.md` with sanitized `<owner>/<private-test-repo>`.
  - GitHub client: `gh()` wraps 401/403 with repo identifier and a hint; original error kept as `cause`; 403 rate‑limit errors pass through unchanged.
  - Tests: `src/clients/github.test.ts` for 401/403 wrapping and rate‑limit pass‑through; `add` tests for `is_private` persistence and 401 hint.

<sup>Written for commit 4f17f9b4cc54b8c25297f0c99ee5e23d87c676f8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

